### PR TITLE
fix: remove containers initialization outside `beforeAll` method

### DIFF
--- a/controllers/src/main/scala/cromwell/pipeline/controller/AuthController.scala
+++ b/controllers/src/main/scala/cromwell/pipeline/controller/AuthController.scala
@@ -1,8 +1,8 @@
 package cromwell.pipeline.controller
 
-import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.RawHeader
+import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import cats.data.Validated.{ Invalid, Valid }
 import cromwell.pipeline.datastorage.dto.auth.{ AuthResponse, SignInRequest, SignUpRequest }

--- a/controllers/src/main/scala/cromwell/pipeline/controller/UserController.scala
+++ b/controllers/src/main/scala/cromwell/pipeline/controller/UserController.scala
@@ -50,5 +50,5 @@ class UserController(userService: UserService)(implicit executionContext: Execut
           }
         }
       )
-    }
+  }
 }

--- a/controllers/src/test/scala/cromwell/pipeline/controller/AuthControllerTest.scala
+++ b/controllers/src/test/scala/cromwell/pipeline/controller/AuthControllerTest.scala
@@ -5,8 +5,8 @@ import akka.http.scaladsl.model.{ HttpEntity, StatusCodes }
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import cromwell.pipeline.controller.AuthController._
 import cromwell.pipeline.datastorage.dto.auth.{ AuthResponse, SignInRequest, SignUpRequest }
-import cromwell.pipeline.service.AuthService
 import cromwell.pipeline.datastorage.utils.validator.DomainValidation
+import cromwell.pipeline.service.AuthService
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{ Assertion, Matchers, WordSpec }
 import play.api.libs.json.Json
@@ -25,7 +25,7 @@ class AuthControllerTest extends WordSpec with Matchers with MockFactory with Sc
 
     "signIn" should {
 
-      "return token headers if user exists" taggedAs (Controller) in {
+      "return token headers if user exists" taggedAs Controller in {
         val signInRequest = SignInRequest("email@cromwell.com", "password")
         val authResponse = AuthResponse(accessToken, refreshToken, accessTokenExpiration)
         val httpEntity = HttpEntity(`application/json`, Json.stringify(Json.toJson(signInRequest)))
@@ -37,7 +37,7 @@ class AuthControllerTest extends WordSpec with Matchers with MockFactory with Sc
         }
       }
 
-      "return Unauthorized status if user doesn't exist" taggedAs (Controller) in {
+      "return Unauthorized status if user doesn't exist" taggedAs Controller in {
         val signInRequest = SignInRequest("email@cromwell.com", "password")
         val httpEntity = HttpEntity(`application/json`, Json.stringify(Json.toJson(signInRequest)))
         (authService.signIn _ when signInRequest).returns(Future(None))
@@ -50,7 +50,7 @@ class AuthControllerTest extends WordSpec with Matchers with MockFactory with Sc
 
     "signUp" should {
 
-      "return token headers if user was successfully registered" taggedAs (Controller) in {
+      "return token headers if user was successfully registered" taggedAs Controller in {
         val signUpRequest = SignUpRequest("JohnDoe@cromwell.com", "Password213", "FirstName", "LastName")
         val authResponse = AuthResponse(accessToken, refreshToken, accessTokenExpiration)
         val httpEntity = HttpEntity(`application/json`, Json.stringify(Json.toJson(signUpRequest)))
@@ -62,7 +62,7 @@ class AuthControllerTest extends WordSpec with Matchers with MockFactory with Sc
         }
       }
 
-      "return BadRequest with fields validation errors" taggedAs (Controller) in {
+      "return BadRequest with fields validation errors" taggedAs Controller in {
         val signUpRequest = SignUpRequest("email", "password", "First-name", "Last-name")
         val authResponse = AuthResponse(accessToken, refreshToken, accessTokenExpiration)
         val httpEntity = HttpEntity(`application/json`, Json.stringify(Json.toJson(signUpRequest)))
@@ -77,7 +77,7 @@ class AuthControllerTest extends WordSpec with Matchers with MockFactory with Sc
         }
       }
 
-      "return BadRequest status if user registration was failed" taggedAs (Controller) in {
+      "return BadRequest status if user registration was failed" taggedAs Controller in {
         val signUpRequest = SignUpRequest("email@cromwell.com", "password", "First-name", "Last-name")
         val httpEntity = HttpEntity(`application/json`, Json.stringify(Json.toJson(signUpRequest)))
         (authService.signUp _ when signUpRequest).returns(Future(throw new RuntimeException("Something wrong.")))
@@ -90,7 +90,7 @@ class AuthControllerTest extends WordSpec with Matchers with MockFactory with Sc
 
     "refresh" should {
 
-      "return updated token headers if refresh token was valid and active" taggedAs (Controller) in {
+      "return updated token headers if refresh token was valid and active" taggedAs Controller in {
         val authResponse = AuthResponse(accessToken, refreshToken, accessTokenExpiration)
         (authService.refreshTokens _ when refreshToken).returns(Some(authResponse))
 
@@ -100,7 +100,7 @@ class AuthControllerTest extends WordSpec with Matchers with MockFactory with Sc
         }
       }
 
-      "return BadRequest status if something was wrong with refresh token" taggedAs (Controller) in {
+      "return BadRequest status if something was wrong with refresh token" taggedAs Controller in {
         (authService.refreshTokens _ when refreshToken).returns(None)
 
         Get(s"/auth/refresh?refreshToken=$refreshToken") ~> authController.route ~> check {

--- a/controllers/src/test/scala/cromwell/pipeline/controller/UserControllerTest.scala
+++ b/controllers/src/test/scala/cromwell/pipeline/controller/UserControllerTest.scala
@@ -30,7 +30,7 @@ class UserControllerTest
 
     "get users by email" should {
 
-      "return the sequence of users" taggedAs (Controller) in {
+      "return the sequence of users" taggedAs Controller in {
         val usersByEmailRequest: String = "@mail"
         val userId = dummyUser.userId
         val uEmailRespSeq: Seq[User] = Seq(dummyUser)
@@ -44,7 +44,7 @@ class UserControllerTest
           responseAs[Seq[User]].size shouldEqual 1
         }
       }
-      "return the internal server error if service fails" taggedAs (Controller) in {
+      "return the internal server error if service fails" taggedAs Controller in {
         val usersByEmailRequest: String = "@mail"
         val accessToken = AccessTokenContent(dummyUser.userId.value)
         when(userService.getUsersByEmail(usersByEmailRequest))
@@ -54,7 +54,7 @@ class UserControllerTest
           status shouldBe StatusCodes.InternalServerError
         }
       }
-      "return the sequence of users when pattern must contain correct number of entries" taggedAs (Controller) in {
+      "return the sequence of users when pattern must contain correct number of entries" taggedAs Controller in {
         val usersByEmailRequest: String = "someDomain.com"
         val userId = dummyUser.userId
 
@@ -75,7 +75,7 @@ class UserControllerTest
     }
 
     "deactivateUserById" should {
-      "return user's entity with false value if user was successfully deactivated" taggedAs (Controller) in {
+      "return user's entity with false value if user was successfully deactivated" taggedAs Controller in {
         val userId = dummyUser.copy(active = false).userId
         val response = UserNoCredentials.fromUser(dummyUser)
         val accessToken = AccessTokenContent(userId.value)
@@ -87,7 +87,7 @@ class UserControllerTest
           status shouldBe StatusCodes.OK
         }
       }
-      "return server error if user deactivation was failed" taggedAs (Controller) in {
+      "return server error if user deactivation was failed" taggedAs Controller in {
         val userId = dummyUser.userId.value
         val accessToken = AccessTokenContent(userId)
         when(userService.deactivateUserById(UserId(userId)))
@@ -97,7 +97,7 @@ class UserControllerTest
           status shouldBe StatusCodes.InternalServerError
         }
       }
-      "return NotFound status if user deactivation was failed" taggedAs (Controller) in {
+      "return NotFound status if user deactivation was failed" taggedAs Controller in {
         val userId = dummyUser.userId.value
         val accessToken = AccessTokenContent(userId)
         when(userService.deactivateUserById(UserId(userId))).thenReturn(Future(None))
@@ -109,7 +109,7 @@ class UserControllerTest
     }
 
     "update" should {
-      "return NoContent status if user was amended" taggedAs (Controller) in {
+      "return NoContent status if user was amended" taggedAs Controller in {
         val userId = dummyUser.userId.value
         val accessToken = AccessTokenContent(userId)
         val request = UserUpdateRequest(dummyUser.email, dummyUser.firstName, dummyUser.lastName)
@@ -121,7 +121,7 @@ class UserControllerTest
         }
       }
 
-      "return NoContent status if user's password was amended" taggedAs (Controller) in {
+      "return NoContent status if user's password was amended" taggedAs Controller in {
         val userId = dummyUser.userId.value
         val accessToken = AccessTokenContent(userId)
         val userPassword = "-Pa$$w0rd-"
@@ -134,7 +134,7 @@ class UserControllerTest
         }
       }
 
-      "return InternalServerError status if user's id doesn't match" taggedAs (Controller) in {
+      "return InternalServerError status if user's id doesn't match" taggedAs Controller in {
         val userId = dummyUser.userId.value
         val accessToken = AccessTokenContent("0")
         val request = UserUpdateRequest(dummyUser.email, dummyUser.firstName, dummyUser.lastName)
@@ -147,7 +147,7 @@ class UserControllerTest
         }
       }
 
-      "return BadRequest status if user's passwords don't match" taggedAs (Controller) in {
+      "return BadRequest status if user's passwords don't match" taggedAs Controller in {
         val userId = dummyUser.userId.value
         val accessToken = AccessTokenContent(userId)
         val userPassword = "-Pa$$w0rd-"

--- a/datasource/src/main/scala/cromwell/pipeline/database/LiquibaseUtils.scala
+++ b/datasource/src/main/scala/cromwell/pipeline/database/LiquibaseUtils.scala
@@ -21,8 +21,7 @@ object LiquibaseUtils {
       val liquibase = new Liquibase(changeLogResourcePath, new ClassLoaderResourceAccessor(), database)
 
       liquibase.update(DefaultContexts, DefaultLabelExpression)
-    }.foreach { _ =>
-      liquibaseConnection.close()
     }
+    liquibaseConnection.close()
   }
 }

--- a/portal/src/it/scala/cromwell/pipeline/controller/AuthControllerItTest.scala
+++ b/portal/src/it/scala/cromwell/pipeline/controller/AuthControllerItTest.scala
@@ -5,11 +5,11 @@ import akka.http.scaladsl.model.{ HttpEntity, StatusCodes }
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import com.dimafeng.testcontainers.{ ForAllTestContainer, PostgreSQLContainer }
 import com.typesafe.config.Config
-import cromwell.pipeline.controller.AuthController._
 import cromwell.pipeline.ApplicationComponents
+import cromwell.pipeline.controller.AuthController._
 import cromwell.pipeline.datastorage.dao.repository.utils.TestUserUtils
+import cromwell.pipeline.datastorage.dto.User
 import cromwell.pipeline.datastorage.dto.auth.{ SignInRequest, SignUpRequest }
-import cromwell.pipeline.datastorage.dto.{ User }
 import cromwell.pipeline.utils.TestContainersUtils
 import org.scalatest.compatible.Assertion
 import org.scalatest.concurrent.ScalaFutures._
@@ -19,15 +19,16 @@ import play.api.libs.json.Json
 class AuthControllerItTest extends WordSpec with Matchers with ScalatestRouteTest with ForAllTestContainer {
 
   override val container: PostgreSQLContainer = TestContainersUtils.getPostgreSQLContainer()
-  container.start()
-  implicit val config: Config = TestContainersUtils.getConfigForPgContainer(container)
-  private val components: ApplicationComponents = new ApplicationComponents()
+  private implicit lazy val config: Config = TestContainersUtils.getConfigForPgContainer(container)
+  private lazy val components: ApplicationComponents = new ApplicationComponents()
 
   import components.controllerModule.authController
   import components.datastorageModule.userRepository
 
-  override protected def beforeAll(): Unit =
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
     components.datastorageModule.pipelineDatabaseEngine.updateSchema()
+  }
 
   private val dummyUser: User = TestUserUtils.getDummyUser()
   private val password: String = "-Pa$$w0rd-"

--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/DatastorageModule.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/DatastorageModule.scala
@@ -1,6 +1,5 @@
 package cromwell.pipeline.datastorage
 
-import com.typesafe.config.Config
 import cromwell.pipeline.database.PipelineDatabaseEngine
 import cromwell.pipeline.datastorage.dao.ProjectEntry
 import cromwell.pipeline.datastorage.dao.entry.UserEntry

--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/User.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/User.scala
@@ -1,11 +1,10 @@
 package cromwell.pipeline.datastorage.dto
 
 import cromwell.pipeline.datastorage.dto.User.UserEmail
-import play.api.libs.json.{ Json, OFormat }
-import play.api.libs.json.Format
-import slick.lifted.MappedTo
-import play.api.libs.json.Reads._
 import play.api.libs.functional.syntax._
+import play.api.libs.json.Reads._
+import play.api.libs.json.{ Format, Json, OFormat }
+import slick.lifted.MappedTo
 
 final case class User(
   userId: UserId,

--- a/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/ProjectRepositoryTest.scala
+++ b/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/ProjectRepositoryTest.scala
@@ -2,32 +2,32 @@ package cromwell.pipeline.datastorage.dao.repository
 
 import com.dimafeng.testcontainers.{ ForAllTestContainer, PostgreSQLContainer }
 import com.typesafe.config.Config
-import cromwell.pipeline.datastorage.dto.{ Project, User }
-import cromwell.pipeline.utils.{ ApplicationConfig, TestContainersUtils }
 import cromwell.pipeline.datastorage.DatastorageModule
 import cromwell.pipeline.datastorage.dao.repository.utils.{ TestProjectUtils, TestUserUtils }
+import cromwell.pipeline.datastorage.dto.{ Project, User }
+import cromwell.pipeline.utils.{ ApplicationConfig, TestContainersUtils }
 import org.scalatest.{ AsyncWordSpec, BeforeAndAfterAll, Matchers }
 
 class ProjectRepositoryTest extends AsyncWordSpec with Matchers with BeforeAndAfterAll with ForAllTestContainer {
 
   override val container: PostgreSQLContainer = TestContainersUtils.getPostgreSQLContainer()
-  container.start()
-  implicit val config: Config = TestContainersUtils.getConfigForPgContainer(container)
-  private val datastorageModule: DatastorageModule = new DatastorageModule(ApplicationConfig.load(config))
+  private lazy val config: Config = TestContainersUtils.getConfigForPgContainer(container)
+  private lazy val datastorageModule: DatastorageModule = new DatastorageModule(ApplicationConfig.load(config))
 
-  override protected def beforeAll(): Unit =
+  override protected def beforeAll(): Unit = {
+    super.beforeAll
     datastorageModule.pipelineDatabaseEngine.updateSchema()
+  }
 
   private val dummyUser: User = TestUserUtils.getDummyUser()
   private val dummyProject: Project = TestProjectUtils.getDummyProject(ownerId = dummyUser.userId)
 
-  import datastorageModule.userRepository
-  import datastorageModule.projectRepository
+  import datastorageModule.{ projectRepository, userRepository }
   "ProjectRepository" when {
 
     "getUserById" should {
 
-      "find newly added project by id" taggedAs (Dao) in {
+      "find newly added project by id" taggedAs Dao in {
         val addUserFuture = userRepository.addUser(dummyUser)
         val result = for {
           _ <- addUserFuture

--- a/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/auth/SecurityDirectiveTest.scala
+++ b/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/auth/SecurityDirectiveTest.scala
@@ -6,13 +6,13 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.testkit.ScalatestRouteTest
+import cromwell.pipeline.datastorage.utils.auth.SecurityDirective._
 import cromwell.pipeline.datastorage.utils.auth.{ AccessTokenContent, AuthContent, SecurityDirective }
+import cromwell.pipeline.utils.{ AuthConfig, ExpirationTimeInSeconds }
 import org.scalatest.{ Matchers, WordSpec }
 import pdi.jwt.algorithms.JwtHmacAlgorithm
 import pdi.jwt.{ Jwt, JwtAlgorithm, JwtClaim }
 import play.api.libs.json.Json
-import cromwell.pipeline.utils.{ AuthConfig, ExpirationTimeInSeconds }
-import SecurityDirective._
 
 class SecurityDirectiveTest extends WordSpec with Matchers with ScalatestRouteTest {
 

--- a/services/src/main/scala/cromwell/pipeline/service/AuthService.scala
+++ b/services/src/main/scala/cromwell/pipeline/service/AuthService.scala
@@ -6,8 +6,8 @@ import java.util.UUID
 import cats.data.OptionT
 import cats.implicits._
 import cromwell.pipeline.datastorage.dao.repository.UserRepository
-import cromwell.pipeline.datastorage.dto.{ User, UserId }
 import cromwell.pipeline.datastorage.dto.auth.{ AuthResponse, SignInRequest, SignUpRequest }
+import cromwell.pipeline.datastorage.dto.{ User, UserId }
 import cromwell.pipeline.datastorage.utils.auth.{ AccessTokenContent, AuthContent, AuthUtils, RefreshTokenContent }
 import cromwell.pipeline.utils.StringUtils
 import play.api.libs.json.Json

--- a/services/src/test/scala/cromwell/pipeline/service/AuthServiceTest.scala
+++ b/services/src/test/scala/cromwell/pipeline/service/AuthServiceTest.scala
@@ -36,17 +36,17 @@ class AuthServiceTest extends WordSpec with Matchers with MockFactory {
 
     "refreshTokens" should {
 
-      "return Auth response for active refresh token" taggedAs (Service) in new RefreshTokenContext(
+      "return Auth response for active refresh token" taggedAs Service in new RefreshTokenContext(
         expirationTimeInSeconds.refreshToken
       ) {
         authService.refreshTokens(refreshToken) shouldBe Some(authResponse)
       }
 
-      "return None for outdated refresh token" taggedAs (Service) in new RefreshTokenContext(lifetime = 0) {
+      "return None for outdated refresh token" taggedAs Service in new RefreshTokenContext(lifetime = 0) {
         authService.refreshTokens(refreshToken) shouldBe None
       }
 
-      "return None for another type of token" taggedAs (Service) in {
+      "return None for another type of token" taggedAs Service in {
         val currentTimestamp = Instant.now.getEpochSecond
         val accessTokenContent: AuthContent = AccessTokenContent(userId = userId.value)
         val accessTokenClaims = JwtClaim(
@@ -61,7 +61,7 @@ class AuthServiceTest extends WordSpec with Matchers with MockFactory {
         authService.refreshTokens(accessToken) shouldBe None
       }
 
-      "return None for wrong token" taggedAs (Service) in {
+      "return None for wrong token" taggedAs Service in {
         val wrongToken = "wrongToken"
 
         (authUtils.getOptJwtClaims _ when wrongToken).returns(None)

--- a/services/src/test/scala/cromwell/pipeline/service/ProjectServiceTest.scala
+++ b/services/src/test/scala/cromwell/pipeline/service/ProjectServiceTest.scala
@@ -1,12 +1,12 @@
 package cromwell.pipeline.service
 
-import cromwell.pipeline.datastorage.dao.repository.{ Dao, ProjectRepository }
+import cromwell.pipeline.datastorage.dao.repository.ProjectRepository
 import cromwell.pipeline.datastorage.dao.repository.utils.TestProjectUtils
 import cromwell.pipeline.datastorage.dto.{ Project, ProjectAdditionRequest }
-import org.scalatest.{ AsyncWordSpec, BeforeAndAfterAll, Matchers }
-import org.scalatestplus.mockito.MockitoSugar
 import org.mockito.Matchers.any
 import org.mockito.Mockito.when
+import org.scalatest.{ AsyncWordSpec, BeforeAndAfterAll, Matchers }
+import org.scalatestplus.mockito.MockitoSugar
 
 import scala.concurrent.Future
 
@@ -19,7 +19,7 @@ class ProjectServiceTest extends AsyncWordSpec with Matchers with MockitoSugar w
   "ProjectServiceTest" when {
 
     "addProject" should {
-      "return id of a new project" taggedAs (Service) in {
+      "return id of a new project" taggedAs Service in {
         val request =
           ProjectAdditionRequest(
             ownerId = dummyProject.ownerId,
@@ -34,7 +34,7 @@ class ProjectServiceTest extends AsyncWordSpec with Matchers with MockitoSugar w
     }
 
     "deactivateProjectById" should {
-      "return deactivated project" taggedAs (Service) in {
+      "return deactivated project" taggedAs Service in {
         val project = dummyProject.copy(active = false)
 
         when(projectRepository.deactivateProjectById(dummyProject.projectId)).thenReturn(Future(0))
@@ -45,7 +45,7 @@ class ProjectServiceTest extends AsyncWordSpec with Matchers with MockitoSugar w
     }
 
     "getProjectById" should {
-      "return project with corresponding id" taggedAs (Service) in {
+      "return project with corresponding id" taggedAs Service in {
         val project = dummyProject.copy(active = false)
 
         when(projectRepository.getProjectById(dummyProject.projectId)).thenReturn(Future(Some(project)))
@@ -53,7 +53,7 @@ class ProjectServiceTest extends AsyncWordSpec with Matchers with MockitoSugar w
         projectService.getProjectById(dummyProject.projectId).map { _ shouldBe Some(project) }
       }
 
-      "return none if project not found" taggedAs (Service) in {
+      "return none if project not found" taggedAs Service in {
 
         when(projectRepository.getProjectById(dummyProject.projectId)).thenReturn(Future(None))
 

--- a/services/src/test/scala/cromwell/pipeline/service/UserServiceTest.scala
+++ b/services/src/test/scala/cromwell/pipeline/service/UserServiceTest.scala
@@ -4,11 +4,10 @@ import cromwell.pipeline.datastorage.dao.repository.UserRepository
 import cromwell.pipeline.datastorage.dao.repository.utils.TestUserUtils
 import cromwell.pipeline.datastorage.dto.user.{ PasswordUpdateRequest, UserUpdateRequest }
 import cromwell.pipeline.datastorage.dto.{ User, UserId, UserNoCredentials }
-import cromwell.pipeline.utils.StringUtils
+import cromwell.pipeline.utils.StringUtils._
 import org.mockito.Mockito._
 import org.scalatest.{ AsyncWordSpec, Matchers }
 import org.scalatestplus.mockito.MockitoSugar
-import StringUtils._
 
 import scala.concurrent.Future
 
@@ -24,7 +23,7 @@ class UserServiceTest extends AsyncWordSpec with Matchers with MockitoSugar {
   "UserService" when {
 
     "invoke UserService" should {
-      "get userResponse sequence from users sequence" taggedAs (Service) in {
+      "get userResponse sequence from users sequence" taggedAs Service in {
 
         when(userRepository.getUsersByEmail(userByEmailRequest)).thenReturn(Future.successful(userRepositoryResp))
         userService.getUsersByEmail(userByEmailRequest).map { result =>
@@ -34,7 +33,7 @@ class UserServiceTest extends AsyncWordSpec with Matchers with MockitoSugar {
     }
 
     "deactivateUserById" should {
-      "returns user's entity with false value" taggedAs (Service) in {
+      "returns user's entity with false value" taggedAs Service in {
         val user: User = dummyUser.copy(userId = userId)
 
         when(userRepository.deactivateUserById(userId)).thenReturn(Future.successful(1))
@@ -45,7 +44,7 @@ class UserServiceTest extends AsyncWordSpec with Matchers with MockitoSugar {
           result shouldBe Some(response)
         }
       }
-      "return None if user wasn't found by Id" taggedAs (Service) in {
+      "return None if user wasn't found by Id" taggedAs Service in {
         when(userRepository.deactivateUserById(userId)).thenReturn(Future.successful(0))
         when(userRepository.getUserById(userId)).thenReturn(Future(None))
 
@@ -56,7 +55,7 @@ class UserServiceTest extends AsyncWordSpec with Matchers with MockitoSugar {
     }
 
     "updateUser" should {
-      "returns success if database handles query" taggedAs (Service) in {
+      "returns success if database handles query" taggedAs Service in {
         val numberId = "123"
         val updatedUser =
           dummyUser.copy(email = "updatedEmail", firstName = "updatedFirstName", lastName = "updatedLastName")
@@ -72,14 +71,14 @@ class UserServiceTest extends AsyncWordSpec with Matchers with MockitoSugar {
     }
 
     "updatePassword" should {
-      "returns success if database handles query" taggedAs (Service) in {
+      "returns success if database handles query" taggedAs Service in {
         val id = "123"
         val salt = "salt"
         val user =
           User(UserId(id), "email@cromwell.com", calculatePasswordHash("password", salt), salt, "name", "lastName")
         val request = PasswordUpdateRequest("password", "newPassword", "newPassword")
         val updatedUser =
-          user.copy(passwordHash = StringUtils.calculatePasswordHash("newPassword", salt), passwordSalt = salt)
+          user.copy(passwordHash = calculatePasswordHash("newPassword", salt), passwordSalt = salt)
 
         when(userRepository.getUserById(UserId(id))).thenReturn(Future(Some(user)))
         when(userRepository.updatePassword(updatedUser)).thenReturn(Future.successful(1))

--- a/utils/src/test/scala/cromwell/pipeline/utils/TestContainersUtils.scala
+++ b/utils/src/test/scala/cromwell/pipeline/utils/TestContainersUtils.scala
@@ -9,20 +9,22 @@ object TestContainersUtils {
   private val user = dbConfig.getString("user")
   private val databaseName = dbConfig.getString("databaseName")
   private val password = dbConfig.getString("password")
+  private val port = dbConfig.getInt("portNumber")
 
   def getPostgreSQLContainer(postgresImageName: String = "postgres:12"): PostgreSQLContainer =
-    PostgreSQLContainer(postgresImageName).configure { c =>
-      c.withDatabaseName(s"$databaseName")
-      c.withUsername(s"$user")
-      c.withPassword(s"$password")
-    }
+    PostgreSQLContainer(
+      dockerImageNameOverride = postgresImageName,
+      databaseName = databaseName,
+      username = user,
+      password = password
+    )
 
   import scala.collection.JavaConverters._
 
   def getConfigForPgContainer(container: PostgreSQLContainer): Config = ConfigFactory
     .parseMap(
       Map(
-        "database.postgres_dc.db.properties.portNumber" -> container.mappedPort(5432)
+        "database.postgres_dc.db.properties.portNumber" -> container.mappedPort(port)
       ).asJava
     )
     .withFallback(ConfigFactory.load())

--- a/womtool/src/main/scala/cromwell/pipeline/womtool/WomTool.scala
+++ b/womtool/src/main/scala/cromwell/pipeline/womtool/WomTool.scala
@@ -7,8 +7,8 @@ import languages.cwl.CwlV1_0LanguageFactory
 import languages.wdl.biscayne.WdlBiscayneLanguageFactory
 import languages.wdl.draft2.WdlDraft2LanguageFactory
 import languages.wdl.draft3.WdlDraft3LanguageFactory
-import spray.json._
 import spray.json.DefaultJsonProtocol._
+import spray.json._
 import wom.executable.WomBundle
 import wom.expression.WomExpression
 import wom.graph.{

--- a/womtool/src/test/scala/cromwell/pipeline/womtool/WomToolTest.scala
+++ b/womtool/src/test/scala/cromwell/pipeline/womtool/WomToolTest.scala
@@ -2,8 +2,8 @@ package cromwell.pipeline.womtool
 
 import cats.data.NonEmptyList
 import cromwell.languages.util.ImportResolver.{ DirectoryResolver, HttpResolver }
-import org.scalatest.{ Matchers, WordSpec }
 import org.scalatest.EitherValues._
+import org.scalatest.{ Matchers, WordSpec }
 import wom.executable.WomBundle
 
 class WomToolTest extends WordSpec with Matchers {


### PR DESCRIPTION
fix: close connection to the database in case of failed migration
fix: use portNumber from `application.conf`
style: remove redundant braces
style: reformat some code in accordance with scalafmt
style: optimize imports everywhere