### PR TITLE
Epmlstrcmw 144 implement get file versions method

### DIFF
--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/Project.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/Project.scala
@@ -10,13 +10,13 @@ import play.api.libs.json._
 import slick.lifted.MappedTo
 
 final case class Project(
-  projectId: ProjectId,
-  ownerId: UserId,
-  name: String,
-  active: Boolean,
-  repository: Option[Repository] = None,
-  visibility: Visibility = Private
-) {
+                          projectId: ProjectId,
+                          ownerId: UserId,
+                          name: String,
+                          active: Boolean,
+                          repository: Option[Repository] = None,
+                          visibility: Visibility = Private
+                        ) {
   def withRepository(repositoryPath: Option[String]): Project =
     this.copy(repository = repositoryPath.map(Repository(_)))
 }
@@ -115,6 +115,11 @@ object PipelineVersion {
 final case class Commit(id: String)
 object Commit {
   implicit val commitFormat: OFormat[Commit] = Json.format[Commit]
+}
+
+final case class FileCommit(commitId: String)
+object FileCommit {
+  implicit val fileCommitFormat: OFormat[FileCommit] = Json.format[FileCommit]
 }
 
 final case class ProjectFile(path: Path, content: String)

--- a/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/utils/TestProjectUtils.scala
+++ b/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/utils/TestProjectUtils.scala
@@ -34,4 +34,7 @@ object TestProjectUtils {
     target: String = s"target-$randomUuidStr",
     commit: Commit = getDummyCommit()
   ): GitLabVersion = GitLabVersion(version, message, target, commit)
+  def getDummyFileCommit(
+    commitId: String = s"$randomUuidStr"
+  ): FileCommit = FileCommit(commitId)
 }

--- a/services/src/main/scala/cromwell/pipeline/service/ProjectVersioning.scala
+++ b/services/src/main/scala/cromwell/pipeline/service/ProjectVersioning.scala
@@ -2,9 +2,9 @@ package cromwell.pipeline.service
 
 import java.nio.file.Path
 
-import cromwell.pipeline.datastorage.dto.{ GitLabVersion, PipelineVersion, Project, ProjectFile }
+import cromwell.pipeline.datastorage.dto.{ GitLabVersion, PipelineVersion, Project, ProjectFile, FileCommit }
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.{ExecutionContext, Future}
 
 trait ProjectVersioning[E >: VersioningException] {
   type AsyncResult[T] = Future[Either[E, T]]
@@ -30,9 +30,13 @@ trait ProjectVersioning[E >: VersioningException] {
     implicit ec: ExecutionContext
   ): AsyncResult[Seq[GitLabVersion]]
 
+  def getFileCommits(project: Project, path: Path)(
+    implicit ec: ExecutionContext
+  ): AsyncResult[Seq[FileCommit]]
+
   def getFileVersions(project: Project, path: Path)(
     implicit ec: ExecutionContext
-  ): AsyncResult[List[GitLabVersion]]
+  ): AsyncResult[Seq[GitLabVersion]]
 
   def getFilesVersions(project: Project, path: Path)(
     implicit ec: ExecutionContext


### PR DESCRIPTION
feat: Implement getFileVersions method

In order to get the file versions it is neccesary
to get the tags and the commits of the file.
The tags will content the commit id, with the
commit id the comparisson can be done to get
which commit was marked as version.