### PR TITLE
EPMLSTRCMW-158: deploy mongoDB with endpoints

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ lazy val datasource = project
   .settings(
     name := "Datasource",
     commonSettings,
-    libraryDependencies ++= dbDependencies :+ configHokon
+    libraryDependencies ++= dbDependencies :+ configHokon :+ mongoBson :+ mongoDriverCore
   )
   .dependsOn(utils)
 
@@ -86,7 +86,7 @@ lazy val utils =
   (project in file("utils"))
     .configs(IntegrationTest)
     .settings(
-      libraryDependencies ++= (jsonDependencies ++ testContainers ++ coreTestDependencies) :+ configHokon :+ cats :+ playFunctional :+ pegdown,
+      libraryDependencies ++= (jsonDependencies ++ testContainers ++ coreTestDependencies ++ dbDependencies) :+ configHokon :+ cats :+ playFunctional :+ pegdown,
       commonSettings
     )
     .dependsOn(model)
@@ -94,14 +94,14 @@ lazy val utils =
 lazy val repositories =
   (project in file("repositories"))
     .settings(
-      libraryDependencies ++= allTestDependencies ++ jsonDependencies :+ cats :+ slick :+ slickPg :+ slickPgCore :+ configHokon :+ playJson :+ catsKernel :+ playFunctional
+      libraryDependencies ++= allTestDependencies ++ jsonDependencies ++ mongoDependencies :+ cats :+ slick :+ slickPg :+ slickPgCore :+ configHokon :+ playJson :+ catsKernel :+ playFunctional
     )
     .configs(IntegrationTest)
     .dependsOn(datasource, model, utils % "compile->compile;test->test")
 
 lazy val services =
   (project in file("services"))
-    .settings(libraryDependencies ++= jsonDependencies ++ cromwellDependencies :+ cats :+ playJson)
+    .settings(libraryDependencies ++= jsonDependencies ++ mongoDependencies ++ cromwellDependencies :+ cats :+ playJson)
     .dependsOn(
       repositories % "compile->compile;test->test",
       utils % "compile->compile;test->test",
@@ -126,6 +126,7 @@ lazy val womtool = (project in file("womtool"))
     libraryDependencies ++= allTestDependencies ++ cromwellDependencies :+ pegdown,
     addCommandAlias("testAll", "; test ; it:test")
   )
+  .dependsOn(repositories)
 
 lazy val model =
   (project in file("model")).settings(libraryDependencies ++= jsonDependencies ++ dbDependencies :+ cats)

--- a/controllers/src/main/scala/cromwell/pipeline/controller/ControllerModule.scala
+++ b/controllers/src/main/scala/cromwell/pipeline/controller/ControllerModule.scala
@@ -14,4 +14,5 @@ class ControllerModule(serviceModule: ServiceModule, authConfig: AuthConfig)(
   lazy val securityDirective: SecurityDirective = new SecurityDirective(authConfig)
   lazy val projectController: ProjectController = new ProjectController(serviceModule.projectService)
   lazy val projectFileController: ProjectFileController = new ProjectFileController(serviceModule.projectFileService)
+  lazy val configurationController = new ProjectConfigurationController(serviceModule.configurationService)
 }

--- a/controllers/src/main/scala/cromwell/pipeline/controller/ProjectConfigurationController.scala
+++ b/controllers/src/main/scala/cromwell/pipeline/controller/ProjectConfigurationController.scala
@@ -1,0 +1,42 @@
+package cromwell.pipeline.controller
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+import cromwell.pipeline.datastorage.dto.auth.AccessTokenContent
+import cromwell.pipeline.datastorage.dto.{ ProjectConfiguration, ProjectId }
+import cromwell.pipeline.service.ProjectConfigurationService
+import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
+
+import scala.concurrent.ExecutionContext
+import scala.util.{ Failure, Success }
+
+class ProjectConfigurationController(projectConfigurationService: ProjectConfigurationService)(
+  implicit val ec: ExecutionContext
+) {
+  val route: AccessTokenContent => Route = _ =>
+    path("configurations") {
+      concat(
+        put {
+          entity(as[ProjectConfiguration]) { request =>
+            onComplete(projectConfigurationService.addConfiguration(request)) {
+              case Failure(e)            => complete(StatusCodes.InternalServerError, e.getMessage)
+              case Success(updateResult) => complete(updateResult)
+            }
+          }
+        },
+        get {
+          concat(
+            parameter('project_id.as[String]) { projectId =>
+              onComplete(projectConfigurationService.getById(ProjectId(projectId))) {
+                case Failure(e)                   => complete(StatusCodes.InternalServerError, e.getMessage)
+                case Success(Some(configuration)) => complete(configuration)
+                case Success(None) =>
+                  complete(StatusCodes.NotFound, s"There is no configuration with project_id: $projectId")
+              }
+            }
+          )
+        }
+      )
+    }
+}

--- a/controllers/src/test/scala/cromwell/pipeline/controller/ProjectConfigurationControllerTest.scala
+++ b/controllers/src/test/scala/cromwell/pipeline/controller/ProjectConfigurationControllerTest.scala
@@ -1,0 +1,71 @@
+package cromwell.pipeline.controller
+
+import java.nio.file.Paths
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import cromwell.pipeline.datastorage.dao.repository.utils.{ TestProjectUtils, TestUserUtils }
+import cromwell.pipeline.datastorage.dto._
+import cromwell.pipeline.datastorage.dto.auth.AccessTokenContent
+import cromwell.pipeline.service.ProjectConfigurationService
+import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
+import org.mockito.Mockito.when
+import org.scalatest.{ AsyncWordSpec, Matchers }
+import org.scalatestplus.mockito.MockitoSugar
+
+import scala.concurrent.Future
+
+class ProjectConfigurationControllerTest extends AsyncWordSpec with Matchers with ScalatestRouteTest with MockitoSugar {
+  private val configurationService = mock[ProjectConfigurationService]
+  private val configurationController = new ProjectConfigurationController(configurationService)
+
+  "ProjectConfigurationController" when {
+    val accessToken = AccessTokenContent(TestUserUtils.getDummyUserId)
+    val configuration = ProjectConfiguration(
+      TestProjectUtils.getDummyProjectId,
+      List(
+        ProjectFileConfiguration(Paths.get("/home/file"), List(FileParameter("nodeName", StringTyped(Some("hello")))))
+      )
+    )
+
+    "update configuration" should {
+      val error = new RuntimeException("Something went wrong")
+
+      "return success for update configuration" in {
+        when(configurationService.addConfiguration(configuration)).thenReturn(Future.successful("Success"))
+        Put("/configurations", configuration) ~> configurationController.route(accessToken) ~> check {
+          status shouldBe StatusCodes.OK
+          entityAs[String] shouldBe "Success"
+        }
+      }
+
+      "return InternalServerError when failure update configuration" in {
+        when(configurationService.addConfiguration(configuration)).thenReturn(Future.failed(error))
+        Put("/configurations", configuration) ~> configurationController.route(accessToken) ~> check {
+          status shouldBe StatusCodes.InternalServerError
+          entityAs[String] shouldBe "Something went wrong"
+        }
+      }
+    }
+
+    "get configuration by project id" should {
+      val projectId = TestProjectUtils.getDummyProjectId
+
+      "return configuration by existing project id" in {
+        when(configurationService.getById(projectId)).thenReturn(Future.successful(Some(configuration)))
+        Get("/configurations?project_id=" + projectId.value) ~> configurationController.route(accessToken) ~> check {
+          status shouldBe StatusCodes.OK
+          entityAs[ProjectConfiguration] shouldBe configuration
+        }
+      }
+
+      "return message about no project with this project id" in {
+        when(configurationService.getById(projectId)).thenReturn(Future.successful(None))
+        Get("/configurations?project_id=" + projectId.value) ~> configurationController.route(accessToken) ~> check {
+          status shouldBe StatusCodes.NotFound
+          entityAs[String] shouldBe s"There is no configuration with project_id: ${projectId.value}"
+        }
+      }
+    }
+  }
+}

--- a/datasource/src/main/scala/cromwell/pipeline/database/MongoEngine.scala
+++ b/datasource/src/main/scala/cromwell/pipeline/database/MongoEngine.scala
@@ -1,0 +1,37 @@
+package cromwell.pipeline.database
+
+import cromwell.pipeline.utils.MongoConfig
+import org.mongodb.scala.{
+  Document,
+  MongoClient,
+  MongoClientSettings,
+  MongoCollection,
+  MongoCredential,
+  MongoDatabase,
+  ServerAddress
+}
+
+import scala.collection.JavaConverters._
+
+class MongoEngine(mongoConfig: MongoConfig) extends AutoCloseable {
+  lazy val mongoCredential: MongoCredential = MongoCredential.createCredential(
+    mongoConfig.user,
+    mongoConfig.authenticationDatabase,
+    mongoConfig.password
+  )
+  lazy val mongoSettings: MongoClientSettings = MongoClientSettings
+    .builder()
+    .applyToSslSettings(p => p.enabled(false))
+    .applyToClusterSettings(
+      p => p.hosts(List(ServerAddress(mongoConfig.host, mongoConfig.port)).asJava)
+    )
+    .credential(mongoCredential)
+    .build()
+  lazy val mongoClient: MongoClient = MongoClient(mongoSettings)
+  lazy val mongoDatabase: MongoDatabase =
+    mongoClient.getDatabase(mongoConfig.database)
+  lazy val mongoCollection: MongoCollection[Document] =
+    mongoDatabase.getCollection(mongoConfig.collection)
+
+  override def close(): Unit = mongoClient.close()
+}

--- a/portal/src/it/resources/application.conf
+++ b/portal/src/it/resources/application.conf
@@ -40,4 +40,14 @@ database {
   liquibase {
     changeLogResourcePath = "liquibase/changelog/changelog-master.xml"
   }
+
+  mongo {
+    user = ${?CMWL_TEST_MONGO_USER}
+    password = ${?CMWL_TEST_MONGO_PASSWORD}
+    host = ${?CMWL_TEST_MONGO_HOST}
+    port = ${?CMWL_TEST_MONGO_PORT}
+    authenticationDatabase = ${?CMWL_TEST_MONGO_AUTH}
+    database = ${?CMWL_TEST_MONGO_DB}
+    collection = ${?CMWL_TEST_MONGO_COLLECTION}
+  }
 }

--- a/portal/src/main/resources/application.conf
+++ b/portal/src/main/resources/application.conf
@@ -47,4 +47,14 @@ database {
     defaultBranch = "master"
     defaultBranch = ${?CMWL_DEFAULT_BRANCH}
   }
+
+  mongo {
+    user = ${?CMWL_MONGO_USER}
+    password = ${?CMWL_MONGO_PASSWORD}
+    host = ${?CMWL_MONGO_HOST}
+    port = ${?CMWL_MONGO_PORT}
+    authenticationDatabase = ${?CMWL_MONGO_AUTH}
+    database = ${?CMWL_MONGO_DB}
+    collection = ${?CMWL_MONGO_COLLECTION}
+  }
 }

--- a/portal/src/main/scala/cromwell/pipeline/CromwellPipelineApp.scala
+++ b/portal/src/main/scala/cromwell/pipeline/CromwellPipelineApp.scala
@@ -40,7 +40,12 @@ object CromwellPipelineApp extends App {
     .withFallback(RejectionHandler.default)
 
   val route = authController.route ~ securityDirective.authenticated {
-    routeCombiner(userController.route, projectController.route, projectFileController.route)
+    routeCombiner(
+      userController.route,
+      projectController.route,
+      projectFileController.route,
+      configurationController.route
+    )
   }
 
   log.info(s"Server online at http://${webServiceConfig.interface}:${webServiceConfig.port}/")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,6 +26,8 @@ object Dependencies {
     val pegdown = "1.6.0"
     val wireMock = "2.26.3"
     val sl4j = "1.7.28"
+    val mongo = "2.9.0"
+    val mongoCore = "3.12.2"
   }
 
   val configHokon = "com.typesafe" % "config" % "1.3.3"
@@ -59,10 +61,16 @@ object Dependencies {
   val wireMock = "com.github.tomakehurst" % "wiremock" % Version.wireMock % Test
   val sl4j = "org.slf4j" % "slf4j-api" % Version.sl4j
   val pegdown = "org.pegdown" % "pegdown" % Version.pegdown % Test
+  val mongo = "org.mongodb.scala" %% "mongo-scala-driver" % Version.mongo
+  val mongoBson = "org.mongodb.scala" %% "mongo-scala-bson" % Version.mongo
+  val mongoDriver = "org.mongodb.scala" %% "mongo-scala-driver" % Version.mongo
+  val mongoDriverCore = "org.mongodb" % "mongodb-driver-core" % Version.mongoCore
+  val bson = "org.mongodb" % "bson" % Version.mongoCore
 
+  lazy val mongoDependencies = Seq(mongo, mongoBson, mongoDriverCore, bson, mongoDriver)
   lazy val akkaDependencies = Seq(akkaActor, akkaStreams, akkaHttp)
   lazy val jsonDependencies = Seq(playJson, akkaHttpJson, jwtCore)
-  lazy val dbDependencies = Seq(slick, slickPg, hikariCP, postgresql, liquibase, yaml)
+  lazy val dbDependencies = Seq(slick, slickPg, hikariCP, postgresql, liquibase, yaml) ++ mongoDependencies
   lazy val coreTestDependencies =
     Seq(mockito, scalaCheck, scalaTest, scalaMock)
   lazy val allTestDependencies =

--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/dao/repository/DocumentRepository.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/dao/repository/DocumentRepository.scala
@@ -1,0 +1,20 @@
+package cromwell.pipeline.datastorage.dao.repository
+
+import org.mongodb.scala.model.Filters._
+import org.mongodb.scala.model.ReplaceOptions
+import org.mongodb.scala.result.UpdateResult
+import org.mongodb.scala.{ Completed, Document, MongoCollection }
+
+import scala.concurrent.Future
+
+class DocumentRepository(collection: MongoCollection[Document]) {
+
+  def addOne(document: Document): Future[Completed] =
+    collection.insertOne(document).toFuture()
+
+  def updateOne(document: Document, fieldName: String, name: String): Future[UpdateResult] =
+    collection.replaceOne(equal(fieldName, name), document, ReplaceOptions().upsert(true)).toFuture()
+
+  def getByParam(field: String, name: String): Future[Seq[Document]] =
+    collection.find(regex(field, name)).toFuture()
+}

--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/FileParameter.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/FileParameter.scala
@@ -1,0 +1,9 @@
+package cromwell.pipeline.datastorage.dto
+
+import play.api.libs.json.{ Json, OFormat }
+
+final case class FileParameter(name: String, typedValue: TypedValue)
+
+object FileParameter {
+  implicit val fileParameterFormat: OFormat[FileParameter] = Json.format
+}

--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/ProjectConfiguration.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/ProjectConfiguration.scala
@@ -1,0 +1,25 @@
+package cromwell.pipeline.datastorage.dto
+
+import java.nio.file.Path
+
+import ProjectFile.pathFormat
+import org.mongodb.scala.bson.collection.immutable.Document
+import play.api.libs.json.{ Json, OFormat }
+
+case class ProjectFileConfiguration(path: Path, inputs: List[FileParameter])
+
+object ProjectFileConfiguration {
+  implicit val projectFileConfigurationFormat: OFormat[ProjectFileConfiguration] = Json.format
+}
+
+case class ProjectConfiguration(projectId: ProjectId, projectFileConfigurations: List[ProjectFileConfiguration])
+
+object ProjectConfiguration {
+  implicit val projectConfigurationFormat: OFormat[ProjectConfiguration] = Json.format
+
+  def toDocument(projectConfiguration: ProjectConfiguration): Document =
+    Document(Json.stringify(Json.toJson(projectConfiguration)))
+
+  def fromDocument(document: Document): ProjectConfiguration =
+    Json.parse(document.toJson()).as[ProjectConfiguration]
+}

--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/TypedValue.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/TypedValue.scala
@@ -1,0 +1,44 @@
+package cromwell.pipeline.datastorage.dto
+
+import java.nio.file.{ Path, Paths }
+
+import ProjectFile.pathFormat
+import cromwell.pipeline.utils.json.AdtJsonFormatter._
+import play.api.libs.json._
+
+sealed trait TypedValue
+final case class StringTyped(value: Option[String]) extends TypedValue
+final case class FileTyped(value: Option[Path]) extends TypedValue
+final case class IntTyped(value: Option[Int]) extends TypedValue
+final case class FloatTyped(value: Option[Float]) extends TypedValue
+final case class BooleanTyped(value: Option[Boolean]) extends TypedValue
+
+object TypedValue {
+  type TypeValuePair = (String, Option[String])
+
+  implicit val typedValueFormat: OFormat[TypedValue] = {
+    implicit val stringTypedFormat: OFormat[StringTyped] = Json.format
+    implicit val fileTyped: OFormat[FileTyped] = Json.format
+    implicit val intTyped: OFormat[IntTyped] = Json.format
+    implicit val floatTyped: OFormat[FloatTyped] = Json.format
+    implicit val booleanTyped: OFormat[BooleanTyped] = Json.format
+
+    adtFormat("$type")(
+      adtCase[StringTyped]("String"),
+      adtCase[FileTyped]("File"),
+      adtCase[IntTyped]("Int"),
+      adtCase[FloatTyped]("Float"),
+      adtCase[BooleanTyped]("Boolean")
+    )
+  }
+
+  def fromPair(pair: TypeValuePair): TypedValue = pair match {
+    case ("String", strLike)   => StringTyped(strLike)
+    case ("File", pathLike)    => FileTyped(pathLike.map(Paths.get(_)))
+    case ("Int", digitLike)    => IntTyped(digitLike.map(_.toInt))
+    case ("Float", digitLike)  => FloatTyped(digitLike.map(_.toFloat))
+    case ("Boolean", boolLike) => BooleanTyped(boolLike.map(_.toBoolean))
+    case (typeVal, _) =>
+      throw new RuntimeException(s"$typeVal is not supported")
+  }
+}

--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/ValidationError.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/ValidationError.scala
@@ -1,3 +1,3 @@
 package cromwell.pipeline.datastorage.dto
 
-case class ValidationError(errors: List[String]) extends Exception
+final case class ValidationError(errors: List[String]) extends Exception

--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/WomToolNode.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/WomToolNode.scala
@@ -1,0 +1,45 @@
+package cromwell.pipeline.datastorage.dto
+
+import play.api.libs.json.{ Format, JsNull, JsResult, JsSuccess, JsValue, Json, Writes }
+
+final case class WomToolNode(name: String, value: Option[String])
+
+object WomToolNode {
+  import OptionFormat._
+
+  implicit object WomToolNodeFormat extends Format[WomToolNode] {
+    override def writes(o: WomToolNode): JsValue = Json.obj(o.name -> o.value)
+
+    override def reads(json: JsValue): JsResult[WomToolNode] = {
+      val (name, value) = json.as[(String, Option[String])]
+      JsSuccess(WomToolNode(name, value))
+    }
+  }
+}
+
+final case class WomToolNodesList(nodes: List[WomToolNode])
+
+object WomToolNodesList {
+
+  implicit object WomToolNodesListFormat extends Format[WomToolNodesList] {
+    override def writes(o: WomToolNodesList): JsValue =
+      Json.obj(o.nodes.map(node => node.name -> Json.toJsFieldJsValueWrapper(node.value)): _*)
+
+    override def reads(json: JsValue): JsResult[WomToolNodesList] = JsSuccess(
+      WomToolNodesList(json.as[List[WomToolNode]])
+    )
+  }
+}
+
+object OptionFormat {
+  implicit def optionFormat[T: Format]: Format[Option[T]] =
+    new Format[Option[T]] {
+      override def reads(json: JsValue): JsResult[Option[T]] =
+        json.validateOpt[T]
+
+      override def writes(o: Option[T]): JsValue = o match {
+        case Some(t) => implicitly[Writes[T]].writes(t)
+        case None    => JsNull
+      }
+    }
+}

--- a/services/src/main/scala/cromwell/pipeline/service/ProjectConfigurationService.scala
+++ b/services/src/main/scala/cromwell/pipeline/service/ProjectConfigurationService.scala
@@ -1,0 +1,18 @@
+package cromwell.pipeline.service
+
+import cromwell.pipeline.datastorage.dao.repository.DocumentRepository
+import cromwell.pipeline.datastorage.dto.{ ProjectConfiguration, ProjectId }
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+class ProjectConfigurationService(repository: DocumentRepository)(implicit ec: ExecutionContext) {
+  import ProjectConfiguration._
+
+  def addConfiguration(projectConfiguration: ProjectConfiguration): Future[String] =
+    repository
+      .updateOne(toDocument(projectConfiguration), "projectId", projectConfiguration.projectId.value)
+      .map(_.toString)
+
+  def getById(projectId: ProjectId): Future[Option[ProjectConfiguration]] =
+    repository.getByParam("projectId", projectId.value).map(_.headOption.map(fromDocument))
+}

--- a/services/src/main/scala/cromwell/pipeline/service/ProjectFileService.scala
+++ b/services/src/main/scala/cromwell/pipeline/service/ProjectFileService.scala
@@ -21,4 +21,14 @@ class ProjectFileService(womTool: WomToolAPI, projectVersioning: ProjectVersioni
     version: Option[PipelineVersion]
   ): Future[Either[VersioningException, String]] =
     projectVersioning.updateFile(project, projectFile, version)
+
+  def buildConfiguration(
+    projectId: ProjectId,
+    projectFile: ProjectFile
+  ): Future[Either[ValidationError, ProjectConfiguration]] =
+    Future(womTool.inputsToList(projectFile.content)).map {
+      case Left(value) => Left(ValidationError(value.toList))
+      case Right(nodes) =>
+        Right(ProjectConfiguration(projectId, List(ProjectFileConfiguration(projectFile.path, nodes))))
+    }
 }

--- a/services/src/main/scala/cromwell/pipeline/service/ServiceModule.scala
+++ b/services/src/main/scala/cromwell/pipeline/service/ServiceModule.scala
@@ -22,4 +22,5 @@ class ServiceModule(
   lazy val projectService: ProjectService = new ProjectService(datastorageModule.projectRepository, projectVersioning)
 
   lazy val projectFileService: ProjectFileService = new ProjectFileService(womToolModule.womTool, projectVersioning)
+  lazy val configurationService = new ProjectConfigurationService(datastorageModule.configurationRepository)
 }

--- a/services/src/test/scala/cromwell/pipeline/service/ProjectConfigurationServiceTest.scala
+++ b/services/src/test/scala/cromwell/pipeline/service/ProjectConfigurationServiceTest.scala
@@ -1,0 +1,53 @@
+package cromwell.pipeline.service
+
+import java.nio.file.Paths
+
+import com.mongodb.client.result.UpdateResult
+import cromwell.pipeline.datastorage.dao.repository.DocumentRepository
+import cromwell.pipeline.datastorage.dao.repository.utils.TestProjectUtils
+import cromwell.pipeline.datastorage.dto.{ FileParameter, ProjectConfiguration, ProjectFileConfiguration, StringTyped }
+import org.mockito.Mockito.when
+import org.scalatest.{ AsyncWordSpec, Matchers }
+import org.scalatestplus.mockito.MockitoSugar
+
+import scala.concurrent.Future
+
+class ProjectConfigurationServiceTest extends AsyncWordSpec with Matchers with MockitoSugar {
+  private val configurationRepository = mock[DocumentRepository]
+  private val configurationService = new ProjectConfigurationService(configurationRepository)
+
+  "ConfigurationServiceTest" when {
+    val configuration = ProjectConfiguration(
+      TestProjectUtils.getDummyProjectId,
+      List(
+        ProjectFileConfiguration(Paths.get("/home/file"), List(FileParameter("nodeName", StringTyped(Some("hello")))))
+      )
+    )
+    val document = ProjectConfiguration.toDocument(configuration)
+    val updateResult = mock[UpdateResult]
+
+    "add configuration" should {
+      "return complete status for creating configuration" in {
+        when(updateResult.toString).thenReturn("Success update")
+        when(configurationRepository.updateOne(document, "projectId", configuration.projectId.value))
+          .thenReturn(Future.successful(updateResult))
+        configurationService.addConfiguration(configuration).map(_ shouldBe "Success update")
+      }
+    }
+
+    "get configuration by project id" should {
+      val projectId = configuration.projectId
+
+      "return nodes by project id" in {
+        when(configurationRepository.getByParam("projectId", projectId.value))
+          .thenReturn(Future.successful(List(document)))
+        configurationService.getById(projectId).map(_ shouldBe Some(configuration))
+      }
+
+      "return None if no configuration was matched" in {
+        when(configurationRepository.getByParam("projectId", projectId.value)).thenReturn(Future.successful(List()))
+        configurationService.getById(projectId).map(_ shouldBe None)
+      }
+    }
+  }
+}

--- a/utils/src/main/scala/cromwell/pipeline/utils/ApplicationConfig.scala
+++ b/utils/src/main/scala/cromwell/pipeline/utils/ApplicationConfig.scala
@@ -22,6 +22,16 @@ final case class AuthConfig(
   expirationTimeInSeconds: ExpirationTimeInSeconds
 ) extends ConfigComponent
 
+final case class MongoConfig(
+  user: String,
+  password: Array[Char],
+  host: String,
+  port: Int,
+  authenticationDatabase: String,
+  database: String,
+  collection: String
+) extends ConfigComponent
+
 final case class ExpirationTimeInSeconds(accessToken: Long, refreshToken: Long, userSession: Long)
 
 class ApplicationConfig(val config: Config) {
@@ -59,6 +69,18 @@ class ApplicationConfig(val config: Config) {
       token = Map("PRIVATE-TOKEN" -> config.getString("database.gitlab.token")),
       defaultFileVersion = config.getString("database.gitlab.defaultFileVersion"),
       defaultBranch = config.getString("database.gitlab.defaultBranch")
+    )
+  }
+
+  lazy val mongoConfig: MongoConfig = {
+    MongoConfig(
+      user = config.getString("database.mongo.user"),
+      password = config.getString("database.mongo.password").toCharArray,
+      host = config.getString("database.mongo.host"),
+      port = config.getInt("database.mongo.port"),
+      authenticationDatabase = config.getString("database.mongo.authenticationDatabase"),
+      database = config.getString("database.mongo.database"),
+      collection = config.getString("database.mongo.collection")
     )
   }
 

--- a/womtool/src/main/scala/cromwell/pipeline/womtool/WomToolAPI.scala
+++ b/womtool/src/main/scala/cromwell/pipeline/womtool/WomToolAPI.scala
@@ -1,6 +1,7 @@
 package cromwell.pipeline.womtool
 
 import cats.data.NonEmptyList
+import cromwell.pipeline.datastorage.dto.FileParameter
 import wom.executable.WomBundle
 
 trait WomToolAPI {
@@ -8,4 +9,6 @@ trait WomToolAPI {
   def validate(content: String): Either[NonEmptyList[String], WomBundle]
 
   def inputs(content: String): Either[NonEmptyList[String], String]
+
+  def inputsToList(content: String): Either[NonEmptyList[String], List[FileParameter]]
 }


### PR DESCRIPTION
Add entry ProjectConfiguration for MongoDB storage.
Add repository for Mongo Document and service for ProjectConfiguration.
Decided not to create my own codec for ProjectConfiguration because of mongo driver strange behavior.
Proofs:
https://stackoverflow.com/questions/49690478/mondodb-driver-codec-for-case-object
https://stackoverflow.com/questions/48059378/codec-for-adt-do-not-compile?rq=1
Now you can get project configuration for wdl file, storage them into mongoDB and find configuration by project name