### PR TITLE
EPMLSTRCMW-160: Change handle Version behavior

### DIFF
--- a/controllers/src/main/scala/cromwell/pipeline/controller/ProjectFileController.scala
+++ b/controllers/src/main/scala/cromwell/pipeline/controller/ProjectFileController.scala
@@ -28,7 +28,7 @@ class ProjectFileController(wdlService: ProjectFileService)(implicit val executi
       path("files") {
         post {
           entity(as[ProjectUpdateFileRequest]) { request =>
-            onComplete(wdlService.uploadFile(request.project, request.projectFile, request.version)) {
+            onComplete(wdlService.uploadFile(request.project, request.projectFile, request.versionName)) {
               case Success(Left(e)) => complete(StatusCodes.ImATeapot, e.getMessage) // TODO: change status code
               case Success(_)       => complete(StatusCodes.OK)
               case Failure(e)       => complete(StatusCodes.InternalServerError, e.getMessage)

--- a/controllers/src/test/scala/cromwell/pipeline/controller/ProjectFileControllerTest.scala
+++ b/controllers/src/test/scala/cromwell/pipeline/controller/ProjectFileControllerTest.scala
@@ -5,14 +5,7 @@ import java.nio.file.Paths
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import cromwell.pipeline.datastorage.dao.repository.utils.{ TestProjectUtils, TestUserUtils }
-import cromwell.pipeline.datastorage.dto.{
-  Commit,
-  FileContent,
-  ProjectFile,
-  ProjectUpdateFileRequest,
-  ValidationError,
-  Version
-}
+import cromwell.pipeline.datastorage.dto.{ FileContent, ProjectFile, ProjectUpdateFileRequest, ValidationError }
 import cromwell.pipeline.datastorage.utils.auth.AccessTokenContent
 import cromwell.pipeline.service.{ ProjectFileService, VersioningException }
 import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
@@ -49,14 +42,14 @@ class ProjectFileControllerTest extends AsyncWordSpec with Matchers with Scalate
     }
 
     "upload file" should {
-      val version = Version("v.0.0.2", "commit message", "this project", Commit("commit_12"))
+      val versionName = "v.0.0.2"
       val accessToken = AccessTokenContent(TestUserUtils.getDummyUserId)
       val project = TestProjectUtils.getDummyProject()
       val projectFile = ProjectFile(Paths.get("folder/test.txt"), "file context")
-      val request = ProjectUpdateFileRequest(project, projectFile, Some(version))
+      val request = ProjectUpdateFileRequest(project, projectFile, Some(versionName))
 
       "return OK response for valid request" taggedAs Controller in {
-        when(projectFileService.uploadFile(project, projectFile, Some(version)))
+        when(projectFileService.uploadFile(project, projectFile, Some(versionName)))
           .thenReturn(Future.successful(Right("Success")))
         Post("/files", request) ~> projectFileController.route(accessToken) ~> check {
           status shouldBe StatusCodes.OK
@@ -64,7 +57,7 @@ class ProjectFileControllerTest extends AsyncWordSpec with Matchers with Scalate
       }
 
       "return InternalServerError for bad request" taggedAs Controller in {
-        when(projectFileService.uploadFile(project, projectFile, Some(version)))
+        when(projectFileService.uploadFile(project, projectFile, Some(versionName)))
           .thenReturn(Future.successful(Left(VersioningException("Bad request"))))
         Post("/files", request) ~> projectFileController.route(accessToken) ~> check {
           status shouldBe StatusCodes.ImATeapot // TODO: change status code

--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/Project.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/Project.scala
@@ -115,12 +115,12 @@ object FileContent {
   implicit lazy val validateFileRequestFormat: OFormat[FileContent] = Json.format[FileContent]
 }
 
-final case class ProjectUpdateFileRequest(project: Project, projectFile: ProjectFile, version: Option[Version])
+final case class ProjectUpdateFileRequest(project: Project, projectFile: ProjectFile, versionName: Option[String])
 
 object ProjectUpdateFileRequest {
   implicit lazy val projectUpdateFileRequestFormat: OFormat[ProjectUpdateFileRequest] =
     ((JsPath \ "project").format[Project] ~ (JsPath \ "projectFile").format[ProjectFile] ~ (JsPath \ "version")
-      .formatNullable[Version])(
+      .formatNullable[String])(
       ProjectUpdateFileRequest.apply,
       unlift(ProjectUpdateFileRequest.unapply)
     )

--- a/services/src/main/scala/cromwell/pipeline/service/ProjectFileService.scala
+++ b/services/src/main/scala/cromwell/pipeline/service/ProjectFileService.scala
@@ -18,7 +18,14 @@ class ProjectFileService(womTool: WomToolAPI, projectVersioning: ProjectVersioni
   def uploadFile(
     project: Project,
     projectFile: ProjectFile,
-    version: Option[Version]
+    versionName: Option[String]
   ): Future[Either[VersioningException, String]] =
-    projectVersioning.updateFile(project, projectFile, version)
+    versionName match {
+      case Some(value) =>
+        projectVersioning.getFilesVersions(project, projectFile.path).flatMap {
+          case Right(versions) => projectVersioning.updateFile(project, projectFile, versions.find(_.name == value))
+          case Left(exception) => Future(Left(exception))
+        }
+      case None => projectVersioning.updateFile(project, projectFile, None)
+    }
 }

--- a/services/src/test/scala/cromwell/pipeline/service/ProjectFileServiceTest.scala
+++ b/services/src/test/scala/cromwell/pipeline/service/ProjectFileServiceTest.scala
@@ -42,19 +42,23 @@ class ProjectFileServiceTest extends AsyncWordSpec with Matchers with MockitoSug
     "upload file" should {
       val project = TestProjectUtils.getDummyProject()
       val projectFile = ProjectFile(Paths.get("test.txt"), "File content")
+      val versionName = "v.0.0.2"
       val version = Version("v.0.0.2", "new version", "this project", Commit("commit_12"))
+
+      when(projectVersioning.getFilesVersions(project, projectFile.path))
+        .thenReturn(Future.successful(Right(List(version))))
 
       "return success message for request" taggedAs Service in {
         when(projectVersioning.updateFile(project, projectFile, Some(version)))
           .thenReturn(Future.successful(Right("Success")))
-        projectFileService.uploadFile(project, projectFile, Some(version)).map(_ shouldBe Right("Success"))
+        projectFileService.uploadFile(project, projectFile, Some(versionName)).map(_ shouldBe Right("Success"))
       }
 
       "return error message for error request" taggedAs Service in {
         when(projectVersioning.updateFile(project, projectFile, Some(version)))
           .thenReturn(Future.successful(Left(VersioningException("Something wrong"))))
         projectFileService
-          .uploadFile(project, projectFile, Some(version))
+          .uploadFile(project, projectFile, Some(versionName))
           .map(_ shouldBe Left(VersioningException("Something wrong")))
       }
     }


### PR DESCRIPTION
ProjectUpdateFileRequest contains VersionName instead of Version.
When uploadFile takes None of VersionName, updateFile with None would execute.
When uploadFile takes some value, first we find full of version by name and then updateFile would execute.