### PR TITLE
EPMLSTRCMW-161_CREATE_DTO_VERSION_FOR_PIPELINE

### DIFF
--- a/controllers/src/main/scala/cromwell/pipeline/controller/ProjectFileController.scala
+++ b/controllers/src/main/scala/cromwell/pipeline/controller/ProjectFileController.scala
@@ -3,12 +3,12 @@ package cromwell.pipeline.controller
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
-import cromwell.pipeline.datastorage.dto.{ FileContent, ProjectUpdateFileRequest }
+import cromwell.pipeline.datastorage.dto.{ FileContent, ProjectUpdateFileRequest, ValidationError }
 import cromwell.pipeline.datastorage.utils.auth.AccessTokenContent
 import cromwell.pipeline.service.ProjectFileService
 import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{ Failure, Success }
 
 class ProjectFileController(wdlService: ProjectFileService)(implicit val executionContext: ExecutionContext) {
@@ -36,8 +36,7 @@ class ProjectFileController(wdlService: ProjectFileService)(implicit val executi
                 (validateResponse, uploadResponse) match {
                   case (Right(_), Right(response)) => StatusCodes.OK.intValue -> response
                   case (Left(_), Right(response))  => StatusCodes.Created.intValue -> response
-                  case (Right(_), Left(response))  => StatusCodes.ImATeapot.intValue -> response.message
-                  case (Left(_), Left(response))   => StatusCodes.ImATeapot.intValue -> response.message
+                  case (_, Left(response))         => StatusCodes.UnprocessableEntity.intValue -> response.message
                 }
               }) {
                 case Success((status, message)) => complete(status, message)

--- a/controllers/src/test/scala/cromwell/pipeline/controller/ProjectFileControllerTest.scala
+++ b/controllers/src/test/scala/cromwell/pipeline/controller/ProjectFileControllerTest.scala
@@ -42,7 +42,7 @@ class ProjectFileControllerTest extends AsyncWordSpec with Matchers with Scalate
     }
 
     "upload file" should {
-      val version = Version("v.0.0.2", "commit message", "this project", Commit("commit_12"))
+      val version = PipelineVersion("v0.0.2")
       val accessToken = AccessTokenContent(TestUserUtils.getDummyUserId)
       val project = TestProjectUtils.getDummyProject()
       val projectFile = ProjectFile(Paths.get("folder/test.txt"), "file context")
@@ -72,7 +72,7 @@ class ProjectFileControllerTest extends AsyncWordSpec with Matchers with Scalate
         when(projectFileService.uploadFile(project, projectFile, Some(version)))
           .thenReturn(Future.successful(Left(VersioningException("Bad request"))))
         Post("/files", request) ~> projectFileController.route(accessToken) ~> check {
-          status shouldBe StatusCodes.ImATeapot // TODO: change status code
+          status shouldBe StatusCodes.UnprocessableEntity
           entityAs[String] shouldBe "Bad request"
         }
       }

--- a/model/src/main/scala/cromwell/pipeline/model/wrapper/VersionValue.scala
+++ b/model/src/main/scala/cromwell/pipeline/model/wrapper/VersionValue.scala
@@ -1,0 +1,33 @@
+package cromwell.pipeline.model.wrapper
+
+import cats.data.{ NonEmptyChain, Validated }
+import cats.implicits.catsStdShowForString
+import cromwell.pipeline.model.validator.Wrapped
+import play.api.libs.json.Format
+
+final class VersionValue private (override val unwrap: Int) extends AnyVal with Wrapped[Int]
+
+object VersionValue extends Wrapped.Companion {
+  type Type = Int
+  type Wrapper = VersionValue
+  type Error = String
+  val pattern = "^[0-9]+$"
+  implicit val versionNumberFormat: Format[VersionValue] = wrapperFormat
+  def increment(value: VersionValue): VersionValue = create(value.unwrap + 1)
+  def fromString(value: String): ValidationResult[Wrapper] =
+    validateString(value) match {
+      case Validated.Valid(content)  => Validated.Valid(create(content.toInt))
+      case Validated.Invalid(errors) => Validated.Invalid(errors)
+    }
+  protected def validateString(value: String): ValidationResult[String] = Validated.cond(
+    value.matches(pattern),
+    value,
+    NonEmptyChain.one("Value should be not negative number")
+  )
+  override protected def create(value: Int): VersionValue = new VersionValue(value)
+  override protected def validate(value: Int): ValidationResult[Int] = Validated.cond(
+    value >= 0,
+    value,
+    NonEmptyChain.one("Value should be not negative")
+  )
+}

--- a/portal/src/main/resources/application.conf
+++ b/portal/src/main/resources/application.conf
@@ -44,5 +44,7 @@ database {
     token = ${?CMWL_GITLAB_TOKEN}
     defaultFileVersion = "v0.0.1"
     defaultFileVersion = ${?CMWL_DEFAULT_FILE_VERSION}
+    defaultBranch = "master"
+    defaultBranch = ${?CMWL_DEFAULT_BRANCH}
   }
 }

--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/File.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/File.scala
@@ -4,7 +4,7 @@ import play.api.libs.functional.syntax._
 import play.api.libs.json.{ Format, JsPath }
 
 object File {
-  case class UpdateFileRequest(branch: String, content: String, commitMessage: String)
+  case class UpdateFileRequest(content: String, commitMessage: String, branch: String)
 
   object UpdateFileRequest {
     implicit val updateFileRequestFormat: Format[UpdateFileRequest] =

--- a/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/utils/TestProjectUtils.scala
+++ b/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/utils/TestProjectUtils.scala
@@ -5,8 +5,11 @@ import java.util.UUID
 import cromwell.pipeline.datastorage.dto._
 import cromwell.pipeline.model.wrapper.UserId
 
+import scala.util.Random
+
 object TestProjectUtils {
 
+  private def randomInt(range: Int): Int = Random.nextInt(range)
   private def randomUuidStr: String = UUID.randomUUID().toString
   def getDummyProjectId: ProjectId = ProjectId(randomUuidStr)
   def getDummyRepository: Repository = Repository(s"repo-$randomUuidStr")
@@ -19,10 +22,16 @@ object TestProjectUtils {
     visibility: Visibility = Private
   ): Project = Project(projectId, ownerId, name, active, repository, visibility)
   def getDummyCommit(id: String = randomUuidStr): Commit = Commit(id)
-  def getDummyVersion(
-    name: String = s"name-$randomUuidStr",
+  def getDummyPipeLineVersion(
+    v1: Int = 1 + randomInt(12),
+    v2: Int = 1 + randomInt(12),
+    v3: Int = 1 + randomInt(12)
+  ): PipelineVersion =
+    PipelineVersion(s"v$v1.$v2.$v3")
+  def getDummyGitLabVersion(
+    version: PipelineVersion = getDummyPipeLineVersion(),
     message: String = s"message-$randomUuidStr",
     target: String = s"target-$randomUuidStr",
     commit: Commit = getDummyCommit()
-  ): Version = Version(name, message, target, commit)
+  ): GitLabVersion = GitLabVersion(version, message, target, commit)
 }

--- a/services/src/main/scala/cromwell/pipeline/service/ProjectFileService.scala
+++ b/services/src/main/scala/cromwell/pipeline/service/ProjectFileService.scala
@@ -1,6 +1,6 @@
 package cromwell.pipeline.service
 
-import cromwell.pipeline.datastorage.dto.{ FileContent, Project, ProjectFile, ValidationError, Version }
+import cromwell.pipeline.datastorage.dto._
 import cromwell.pipeline.womtool.WomToolAPI
 
 import scala.concurrent.{ ExecutionContext, Future }
@@ -18,7 +18,7 @@ class ProjectFileService(womTool: WomToolAPI, projectVersioning: ProjectVersioni
   def uploadFile(
     project: Project,
     projectFile: ProjectFile,
-    version: Option[Version]
+    version: Option[PipelineVersion]
   ): Future[Either[VersioningException, String]] =
     projectVersioning.updateFile(project, projectFile, version)
 }

--- a/services/src/main/scala/cromwell/pipeline/service/ProjectVersioning.scala
+++ b/services/src/main/scala/cromwell/pipeline/service/ProjectVersioning.scala
@@ -2,7 +2,7 @@ package cromwell.pipeline.service
 
 import java.nio.file.Path
 
-import cromwell.pipeline.datastorage.dto.{ Project, ProjectFile, Version }
+import cromwell.pipeline.datastorage.dto.{ GitLabVersion, PipelineVersion, Project, ProjectFile }
 
 import scala.concurrent.{ ExecutionContext, Future }
 
@@ -10,7 +10,7 @@ trait ProjectVersioning[E >: VersioningException] {
   type AsyncResult[T] = Future[Either[E, T]]
   type ProjectFiles = List[ProjectFile]
 
-  def updateFile(project: Project, projectFile: ProjectFile, version: Option[Version])(
+  def updateFile(project: Project, projectFile: ProjectFile, version: Option[PipelineVersion] = None)(
     implicit ec: ExecutionContext
   ): AsyncResult[String]
 
@@ -28,21 +28,21 @@ trait ProjectVersioning[E >: VersioningException] {
 
   def getProjectVersions(project: Project)(
     implicit ec: ExecutionContext
-  ): AsyncResult[Seq[Version]]
+  ): AsyncResult[Seq[GitLabVersion]]
 
   def getFileVersions(project: Project, path: Path)(
     implicit ec: ExecutionContext
-  ): AsyncResult[List[Version]]
+  ): AsyncResult[List[GitLabVersion]]
 
   def getFilesVersions(project: Project, path: Path)(
     implicit ec: ExecutionContext
-  ): AsyncResult[List[Version]]
+  ): AsyncResult[List[GitLabVersion]]
 
-  def getFileTree(project: Project, version: Option[Version] = None)(
+  def getFileTree(project: Project, version: Option[PipelineVersion] = None)(
     implicit ec: ExecutionContext
   ): AsyncResult[List[String]]
 
-  def getFile(project: Project, path: Path, version: Option[Version] = None)(
+  def getFile(project: Project, path: Path, version: Option[PipelineVersion] = None)(
     implicit ec: ExecutionContext
   ): AsyncResult[ProjectFile]
 }

--- a/services/src/test/resources/application.conf
+++ b/services/src/test/resources/application.conf
@@ -3,6 +3,7 @@
         url = "https://gitlab.com/api/v4/"
         path = "AdminLogin" //TODO: Change AdminLogin for real GitLab login
         token = "XXXX" //TODO: Change for real GitLab private token
-        defaultFileVersion = "v0.0.1"
+        defaultFileVersion = "v.0.0.1"
+        defaultBranch = "master"
       }
   }

--- a/services/src/test/scala/cromwell/pipeline/service/ProjectFileServiceTest.scala
+++ b/services/src/test/scala/cromwell/pipeline/service/ProjectFileServiceTest.scala
@@ -4,7 +4,7 @@ import java.nio.file.Paths
 
 import cats.data.NonEmptyList
 import cromwell.pipeline.datastorage.dao.repository.utils.TestProjectUtils
-import cromwell.pipeline.datastorage.dto.{ Commit, FileContent, ProjectFile, ValidationError, Version }
+import cromwell.pipeline.datastorage.dto.{ FileContent, ProjectFile, ValidationError }
 import cromwell.pipeline.womtool.WomTool
 import org.mockito.Matchers.any
 import org.mockito.Mockito.when
@@ -42,7 +42,7 @@ class ProjectFileServiceTest extends AsyncWordSpec with Matchers with MockitoSug
     "upload file" should {
       val project = TestProjectUtils.getDummyProject()
       val projectFile = ProjectFile(Paths.get("test.txt"), "File content")
-      val version = Version("v.0.0.2", "new version", "this project", Commit("commit_12"))
+      val version = TestProjectUtils.getDummyPipeLineVersion()
 
       "return success message for request" taggedAs Service in {
         when(projectVersioning.updateFile(project, projectFile, Some(version)))

--- a/utils/src/main/scala/cromwell/pipeline/utils/ApplicationConfig.scala
+++ b/utils/src/main/scala/cromwell/pipeline/utils/ApplicationConfig.scala
@@ -8,7 +8,13 @@ sealed trait ConfigComponent
 
 final case class WebServiceConfig(interface: String, port: Int) extends ConfigComponent
 
-final case class GitLabConfig(url: String, idPath: String, token: Map[String, String], defaultFileVersion: String) extends ConfigComponent
+final case class GitLabConfig(
+  url: String,
+  idPath: String,
+  token: Map[String, String],
+  defaultFileVersion: String,
+  defaultBranch: String
+) extends ConfigComponent
 
 final case class AuthConfig(
   secretKey: String,
@@ -51,7 +57,8 @@ class ApplicationConfig(val config: Config) {
       url = config.getString("database.gitlab.url"),
       idPath = config.getString("database.gitlab.path") + "%2F",
       token = Map("PRIVATE-TOKEN" -> config.getString("database.gitlab.token")),
-      defaultFileVersion = config.getString("database.gitlab.defaultFileVersion")
+      defaultFileVersion = config.getString("database.gitlab.defaultFileVersion"),
+      defaultBranch = config.getString("database.gitlab.defaultBranch")
     )
   }
 


### PR DESCRIPTION
Divide Version onto PipelineVersion and GitLabVersion.
GitLabVersion contains full information of tag and PipelineVersion contains only name of tag.
PipelineVersion was added to friendly input for users, by PipelineVersion we can get GitLabVersion