### PR TITLE
EPMLSTRCMW-175-GitLabProjectVersioning

### DIFF
--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/Project.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/Project.scala
@@ -34,6 +34,12 @@ object Project {
     )
 }
 
+final case class PostProject(name: String)
+
+object PostProject {
+  implicit lazy val postProject: OFormat[PostProject] = Json.format[PostProject]
+}
+
 final case class ProjectId(value: String) extends MappedTo[String]
 
 object ProjectId {
@@ -62,6 +68,12 @@ final case class ProjectUpdateRequest(projectId: ProjectId, name: String, reposi
 
 object ProjectUpdateRequest {
   implicit val updateRequestFormat: OFormat[ProjectUpdateRequest] = Json.format[ProjectUpdateRequest]
+}
+
+final case class RepositoryId(id: String)
+
+object RepositoryId {
+  implicit val gitlabProjectFormat: OFormat[RepositoryId] = Json.format[RepositoryId]
 }
 
 final case class GitLabVersion(name: PipelineVersion, message: String, target: String, commit: Commit)

--- a/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/utils/TestProjectUtils.scala
+++ b/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/utils/TestProjectUtils.scala
@@ -28,6 +28,9 @@ object TestProjectUtils {
     v3: Int = 1 + randomInt(12)
   ): PipelineVersion =
     PipelineVersion(s"v$v1.$v2.$v3")
+  def getDummyRepositoryId(
+    id: String = randomUuidStr
+  ): RepositoryId = RepositoryId(id)
   def getDummyGitLabVersion(
     version: PipelineVersion = getDummyPipeLineVersion(),
     message: String = s"message-$randomUuidStr",


### PR DESCRIPTION
Assign the gitlab id instead of project id that
was used in the create repository method. The
git lab id is being assign to the response of
the method.