### PR TITLE
Epmlstrcmw-191: Gitlab AWS connection

### DIFF
--- a/portal/src/main/resources/application.conf
+++ b/portal/src/main/resources/application.conf
@@ -37,7 +37,7 @@ database {
   }
 
   gitlab {
-    url = "https://gitlab.com/api/v4/"
+    url = "https://gitlab.cmwl.ru.com/api/v4/"
     path = "admin"
     path = ${?CMWL_GITLAB_USER_NAME}
     token = "token"

--- a/services/src/test/resources/application.conf
+++ b/services/src/test/resources/application.conf
@@ -1,6 +1,6 @@
   database {
       gitlab {
-        url = "https://gitlab.com/api/v4/"
+        url = "https://gitlab.cmwl.ru.com/api/v4/"
         path = "AdminLogin" //TODO: Change AdminLogin for real GitLab login
         token = "XXXX" //TODO: Change for real GitLab private token
         defaultFileVersion = "v.0.0.1"


### PR DESCRIPTION
We've moved gitlab to the remote server

More detailed information about gitlab connection you can find by this [link](https://github.com/EpamLifeSciencesTeam/cmwl_pipeline/wiki/Getting-started-guide-for-developers#prepare-gitlab)

These small changes are related to this [commit](https://github.com/EpamLifeSciencesTeam/cmwl_pipeline_core/commit/7044e212efa4767a9a9150992c564847e8f74d30)