### PR TITLE
Fix model for GitLab response

### DIFF
--- a/controllers/src/main/scala/cromwell/pipeline/controller/ProjectController.scala
+++ b/controllers/src/main/scala/cromwell/pipeline/controller/ProjectController.scala
@@ -20,7 +20,7 @@ class ProjectController(projectService: ProjectService)(
       concat(
         get {
           parameter('name.as[String]) { name =>
-            onComplete(projectService.getProjectByName(name, accessToken.userId)) {
+            onComplete(projectService.getUserProjectByName(name, accessToken.userId)) {
               case Success(project)                         => complete(project)
               case Failure(e: ProjectNotFoundException)     => complete(StatusCodes.NotFound, e.getMessage)
               case Failure(e: ProjectAccessDeniedException) => complete(StatusCodes.Forbidden, e.getMessage)

--- a/controllers/src/test/scala/cromwell/pipeline/controller/ProjectControllerTest.scala
+++ b/controllers/src/test/scala/cromwell/pipeline/controller/ProjectControllerTest.scala
@@ -23,15 +23,15 @@ class ProjectControllerTest extends AsyncWordSpec with Matchers with ScalatestRo
       "return a object of project type" taggedAs Controller in {
         val projectByName: String = "dummyProject"
         val dummyProject: Project = TestProjectUtils.getDummyProject()
-        val getProjectByNameResponse: Option[Project] = Option(dummyProject)
+        val getProjectByNameResponse: Project = dummyProject
 
         val accessToken = AccessTokenContent(dummyProject.ownerId)
-        when(projectService.getProjectByName(projectByName, accessToken.userId))
+        when(projectService.getUserProjectByName(projectByName, accessToken.userId))
           .thenReturn(Future.successful(getProjectByNameResponse))
 
         Get("/projects?name=" + projectByName) ~> projectController.route(accessToken) ~> check {
           status shouldBe StatusCodes.OK
-          responseAs[Option[Project]] shouldEqual (getProjectByNameResponse)
+          responseAs[Project] shouldEqual getProjectByNameResponse
         }
       }
     }
@@ -45,7 +45,7 @@ class ProjectControllerTest extends AsyncWordSpec with Matchers with ScalatestRo
 
         when(
           projectService.deactivateProjectById(dummyProject.projectId, accessToken.userId)
-        ).thenReturn(Future.successful(Some(deactivatedProject)))
+        ).thenReturn(Future.successful(deactivatedProject))
 
         Delete("/projects", request) ~> projectController.route(accessToken) ~> check {
           responseAs[Project] shouldBe deactivatedProject

--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/Project.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/Project.scala
@@ -70,7 +70,7 @@ object ProjectUpdateRequest {
   implicit val updateRequestFormat: OFormat[ProjectUpdateRequest] = Json.format[ProjectUpdateRequest]
 }
 
-final case class RepositoryId(id: String)
+final case class RepositoryId(id: Int)
 
 object RepositoryId {
   implicit val gitlabProjectFormat: OFormat[RepositoryId] = Json.format[RepositoryId]
@@ -207,12 +207,12 @@ object ProjectUpdateFileRequest {
  */
 final case class DummyResponseBody()
 object DummyResponseBody {
-  implicit val dummyResponseBodyNonStrictReads = Reads.pure(DummyResponseBody())
-  implicit val dummyResponseBodyWrites = OWrites[DummyResponseBody](_ => Json.obj())
+  implicit val dummyResponseBodyNonStrictReads: Reads[DummyResponseBody] = Reads.pure(DummyResponseBody())
+  implicit val dummyResponseBodyWrites: OWrites[DummyResponseBody] = OWrites[DummyResponseBody](_ => Json.obj())
 }
 
 /**
- * Wrapper type contains success response message from [[cromwell.pipeline.service.SuccessResponseBody]]
+ * Wrapper type contains success response message
  *
  * @param message any response info which signals successful request
  */
@@ -220,11 +220,12 @@ final case class SuccessResponseMessage(message: String) extends AnyVal
 
 object SuccessResponseMessage {
   implicit lazy val successResponseMessageFormat: OFormat[SuccessResponseMessage] =
-    Json.format[SuccessResponseMessage]
+    Json.format[SuccessResponseMessage] // todo Json.valueFormat ?
 }
 
 /**
- * Wrapper type contains empty response message to use in [[cromwell.pipeline.service.HttpClient]]
+ * Wrapper type contains empty payload
+ * Useful if you want to post something and payload doesn't matter
  *
  * @param message empty payload message
  */

--- a/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/utils/TestProjectUtils.scala
+++ b/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/utils/TestProjectUtils.scala
@@ -9,7 +9,8 @@ import scala.util.Random
 
 object TestProjectUtils {
 
-  private def randomInt(range: Int): Int = Random.nextInt(range)
+  private val defaultRange: Int = 12
+  private def randomInt(range: Int = defaultRange): Int = Random.nextInt(range)
   private def randomUuidStr: String = UUID.randomUUID().toString
   def getDummyProjectId: ProjectId = ProjectId(randomUuidStr)
   def getDummyRepository: Repository = Repository(s"repo-$randomUuidStr")
@@ -23,13 +24,13 @@ object TestProjectUtils {
   ): Project = Project(projectId, ownerId, name, active, repository, visibility)
   def getDummyCommit(id: String = randomUuidStr): Commit = Commit(id)
   def getDummyPipeLineVersion(
-    v1: Int = 1 + randomInt(12),
-    v2: Int = 1 + randomInt(12),
-    v3: Int = 1 + randomInt(12)
+    v1: Int = 1 + randomInt(),
+    v2: Int = 1 + randomInt(),
+    v3: Int = 1 + randomInt()
   ): PipelineVersion =
     PipelineVersion(s"v$v1.$v2.$v3")
   def getDummyRepositoryId(
-    id: String = randomUuidStr
+    id: Int = randomInt()
   ): RepositoryId = RepositoryId(id)
   def getDummyGitLabVersion(
     version: PipelineVersion = getDummyPipeLineVersion(),

--- a/services/src/test/scala/cromwell/pipeline/service/GitLabProjectVersioningTest.scala
+++ b/services/src/test/scala/cromwell/pipeline/service/GitLabProjectVersioningTest.scala
@@ -65,7 +65,11 @@ class GitLabProjectVersioningTest
 
         when(request(postProject)).thenReturn(
           Future.successful(
-            Response[RepositoryId](HttpStatusCodes.Created, SuccessResponseBody[RepositoryId](repositoryId), EmptyHeaders)
+            Response[RepositoryId](
+              HttpStatusCodes.Created,
+              SuccessResponseBody[RepositoryId](repositoryId),
+              EmptyHeaders
+            )
           )
         )
 
@@ -75,19 +79,22 @@ class GitLabProjectVersioningTest
       }
 
       "throw new VersioningException with 400 response" taggedAs Service in {
+        val errorMsg = "The repository was not created. Response status: 400"
         when(request(postProject)).thenReturn(
           Future.successful(
             Response[RepositoryId](
               HttpStatusCodes.BadRequest,
-              FailureResponseBody("The repository was not created. Response status: 400"),
+              FailureResponseBody(errorMsg),
               EmptyHeaders
             )
           )
         )
         gitLabProjectVersioning.createRepository(activeProject).map {
-          _ shouldBe Left(
-            VersioningException.RepositoryException("The repository was not created. Response status: 400")
-          )
+          _ shouldBe Left {
+            VersioningException.RepositoryException {
+              s"The repository was not created. Response status: 400; Response body [$errorMsg]"
+            }
+          }
         }
       }
     }

--- a/services/src/test/scala/cromwell/pipeline/service/ProjectServiceTest.scala
+++ b/services/src/test/scala/cromwell/pipeline/service/ProjectServiceTest.scala
@@ -4,6 +4,7 @@ import cromwell.pipeline.datastorage.dao.repository.ProjectRepository
 import cromwell.pipeline.datastorage.dao.repository.utils.TestProjectUtils
 import cromwell.pipeline.datastorage.dto.{ Project, ProjectAdditionRequest, ProjectId }
 import cromwell.pipeline.model.wrapper.UserId
+import cromwell.pipeline.service.Exceptions.ProjectNotFoundException
 import org.mockito.Matchers.any
 import org.mockito.Mockito.when
 import org.scalatest.{ AsyncWordSpec, BeforeAndAfterAll, Matchers }
@@ -43,19 +44,19 @@ class ProjectServiceTest extends AsyncWordSpec with Matchers with MockitoSugar w
         when(projectRepository.deactivateProjectById(projectId)).thenReturn(Future(0))
         when(projectRepository.getProjectById(projectId)).thenReturn(Future(Some(project)))
 
-        projectService.deactivateProjectById(projectId, userId).map { _ shouldBe Some(project) }
+        projectService.deactivateProjectById(projectId, userId).map { _ shouldBe project }
       }
     }
 
-    "getProjectById" should {
+    "getUserProjectById" should {
+      val userId = UserId.random
       "return project with corresponding id" taggedAs Service in {
         val projectId = ProjectId("projectId")
-        val userId = UserId.random
         val project = TestProjectUtils.getDummyProject(projectId, userId)
 
         when(projectRepository.getProjectById(projectId)).thenReturn(Future(Some(project)))
 
-        projectService.getProjectById(projectId).map { _ shouldBe Some(project) }
+        projectService.getUserProjectById(projectId, userId).map { _ shouldBe project }
       }
 
       "return none if project not found" taggedAs Service in {
@@ -63,7 +64,7 @@ class ProjectServiceTest extends AsyncWordSpec with Matchers with MockitoSugar w
 
         when(projectRepository.getProjectById(projectId)).thenReturn(Future(None))
 
-        projectService.getProjectById(projectId).map { _ shouldBe None }
+        projectService.getUserProjectById(projectId, userId).failed.map { _ shouldBe ProjectNotFoundException() }
       }
     }
   }


### PR DESCRIPTION
This PR solves two issues.
1. `id` of a project in GitLab is an `Integer` (see https://docs.gitlab.com/ee/api/projects.html#get-single-project), not a `String`. In Cromwell Pipeline we treated it as a `String`. This caused the app to say that the project was not created even though it was created successfully.
2. Some of the `ProjectService` methods said that they return `Future[Option[Project]]`, but there was no way to get `Future(None)` from them. Also, there was a lot of duplication when checking user rights to read / modify `Project`.