### PR TITLE
EPMLSTRCMW-206 Explicitly store and use GitLab ID

### DIFF
--- a/controllers/src/main/scala/cromwell/pipeline/controller/ProjectController.scala
+++ b/controllers/src/main/scala/cromwell/pipeline/controller/ProjectController.scala
@@ -4,7 +4,7 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import cromwell.pipeline.datastorage.dto.auth.AccessTokenContent
-import cromwell.pipeline.datastorage.dto.{ ProjectAdditionRequest, ProjectDeleteRequest, ProjectUpdateRequest }
+import cromwell.pipeline.datastorage.dto.{ ProjectAdditionRequest, ProjectDeleteRequest, ProjectUpdateNameRequest }
 import cromwell.pipeline.service.Exceptions.{ ProjectAccessDeniedException, ProjectNotFoundException }
 import cromwell.pipeline.service.{ ProjectService, VersioningException }
 import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
@@ -52,8 +52,8 @@ class ProjectController(projectService: ProjectService)(
           }
         },
         put {
-          entity(as[ProjectUpdateRequest]) { request =>
-            onComplete(projectService.updateProject(request, accessToken.userId)) {
+          entity(as[ProjectUpdateNameRequest]) { request =>
+            onComplete(projectService.updateProjectName(request, accessToken.userId)) {
               case Success(_) => complete(StatusCodes.NoContent)
               case Failure(e) => complete(StatusCodes.InternalServerError, e.getMessage)
             }

--- a/controllers/src/main/scala/cromwell/pipeline/controller/ProjectFileController.scala
+++ b/controllers/src/main/scala/cromwell/pipeline/controller/ProjectFileController.scala
@@ -3,25 +3,18 @@ package cromwell.pipeline.controller
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
-import cromwell.pipeline.datastorage.dto.SuccessResponseMessage
 import cromwell.pipeline.datastorage.dto.auth.AccessTokenContent
-import cromwell.pipeline.service.VersioningException.{
-  FileException,
-  GitException,
-  HttpException,
-  ProjectException,
-  RepositoryException
-}
 import cromwell.pipeline.datastorage.dto.{
   ProjectBuildConfigurationRequest,
-  ProjectFileContent,
-  ProjectUpdateFileRequest
+  ProjectUpdateFileRequest,
+  ValidateFileContentRequest,
+  SuccessResponseMessage
 }
-
-import cromwell.pipeline.service.{ ProjectFileService }
+import cromwell.pipeline.service.ProjectFileService
+import cromwell.pipeline.service.VersioningException._
 import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
 
-import scala.concurrent.{ ExecutionContext }
+import scala.concurrent.ExecutionContext
 import scala.util.{ Failure, Success }
 
 class ProjectFileController(wdlService: ProjectFileService)(implicit val executionContext: ExecutionContext) {
@@ -30,8 +23,8 @@ class ProjectFileController(wdlService: ProjectFileService)(implicit val executi
     concat(
       path("files" / "validation") {
         post {
-          entity(as[ProjectFileContent]) { request =>
-            onComplete(wdlService.validateFile(request)) {
+          entity(as[ValidateFileContentRequest]) { request =>
+            onComplete(wdlService.validateFile(request.content)) {
               case Success(Left(e)) => complete(StatusCodes.Conflict, e.errors)
               case Success(_)       => complete(StatusCodes.OK)
               case Failure(e)       => complete(StatusCodes.InternalServerError, e.getMessage)

--- a/controllers/src/test/scala/cromwell/pipeline/controller/ProjectControllerTest.scala
+++ b/controllers/src/test/scala/cromwell/pipeline/controller/ProjectControllerTest.scala
@@ -4,7 +4,7 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import cromwell.pipeline.datastorage.dao.repository.utils.{ TestProjectUtils, TestUserUtils }
 import cromwell.pipeline.datastorage.dto.auth.AccessTokenContent
-import cromwell.pipeline.datastorage.dto.{ Project, ProjectDeleteRequest, ProjectUpdateRequest }
+import cromwell.pipeline.datastorage.dto.{ Project, ProjectDeleteRequest, ProjectUpdateNameRequest }
 import cromwell.pipeline.service.ProjectService
 import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
 import org.mockito.Mockito.when
@@ -72,9 +72,9 @@ class ProjectControllerTest extends AsyncWordSpec with Matchers with ScalatestRo
         val userId = TestUserUtils.getDummyUserId
         val accessToken = AccessTokenContent(userId)
         val dummyProject = TestProjectUtils.getDummyProject()
-        val request = ProjectUpdateRequest(dummyProject.projectId, dummyProject.name, dummyProject.repository)
+        val request = ProjectUpdateNameRequest(dummyProject.projectId, dummyProject.name)
 
-        when(projectService.updateProject(request, userId)).thenReturn(Future.successful(1))
+        when(projectService.updateProjectName(request, userId)).thenReturn(Future.successful(1))
 
         Put("/projects", request) ~> projectController.route(accessToken) ~> check {
           status shouldBe StatusCodes.NoContent
@@ -85,9 +85,9 @@ class ProjectControllerTest extends AsyncWordSpec with Matchers with ScalatestRo
         val userId = TestUserUtils.getDummyUserId
         val accessToken = AccessTokenContent(userId)
         val dummyProject = TestProjectUtils.getDummyProject()
-        val request = ProjectUpdateRequest(dummyProject.projectId, dummyProject.name, dummyProject.repository)
+        val request = ProjectUpdateNameRequest(dummyProject.projectId, dummyProject.name)
 
-        when(projectService.updateProject(request, userId))
+        when(projectService.updateProjectName(request, userId))
           .thenReturn(Future.failed(new RuntimeException("Something wrong")))
 
         Put("/projects", request) ~> projectController.route(accessToken) ~> check {

--- a/controllers/src/test/scala/cromwell/pipeline/controller/ProjectFileControllerTest.scala
+++ b/controllers/src/test/scala/cromwell/pipeline/controller/ProjectFileControllerTest.scala
@@ -24,10 +24,11 @@ class ProjectFileControllerTest extends AsyncWordSpec with Matchers with Scalate
 
     "validate file" should {
       val content = ProjectFileContent("task hello {}")
+      val request = ValidateFileContentRequest(content)
 
       "return OK response to valid file" taggedAs Controller in {
         when(projectFileService.validateFile(content)).thenReturn(Future.successful(Right(())))
-        Post("/files/validation", content) ~> projectFileController.route(accessToken) ~> check {
+        Post("/files/validation", request) ~> projectFileController.route(accessToken) ~> check {
           status shouldBe StatusCodes.OK
         }
       }
@@ -35,7 +36,7 @@ class ProjectFileControllerTest extends AsyncWordSpec with Matchers with Scalate
       "return error response to invalid file" taggedAs Controller in {
         when(projectFileService.validateFile(content))
           .thenReturn(Future.successful(Left(ValidationError(List("Miss close bracket")))))
-        Post("/files/validation", content) ~> projectFileController.route(accessToken) ~> check {
+        Post("/files/validation", request) ~> projectFileController.route(accessToken) ~> check {
           status shouldBe StatusCodes.Conflict
           entityAs[List[String]] shouldBe List("Miss close bracket")
         }

--- a/datasource/src/main/resources/liquibase/changelog/changelog-0.1.xml
+++ b/datasource/src/main/resources/liquibase/changelog/changelog-0.1.xml
@@ -86,4 +86,15 @@
         <addNotNullConstraint constraintName="results_nn" tableName="run" columnName="results"/>
     </changeSet>
 
+    <changeSet id="change_repository_id_type" author="nikita_miazin">
+        <delete tableName="run"/>
+        <delete tableName="project"/>
+        <dropColumn tableName="project" columnName="repository"/>
+        <addColumn tableName="project">
+            <column name="repository_id" type="${integer.type}">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
 </databaseChangeLog>

--- a/datasource/src/main/resources/liquibase/properties.xml
+++ b/datasource/src/main/resources/liquibase/properties.xml
@@ -11,5 +11,6 @@
     <property name="text.type" value="TEXT" dbms="postgresql"/>
     <property name="boolean.type" value="BOOLEAN" dbms="postgresql"/>
     <property name="timestamp.type" value="TIMESTAMP" dbms="postgresql"/>
+    <property name="integer.type" value="INTEGER" dbms="postgresql"/>
 
 </databaseChangeLog>

--- a/portal/src/main/resources/application.conf
+++ b/portal/src/main/resources/application.conf
@@ -38,8 +38,6 @@ database {
 
   gitlab {
     url = "https://gitlab.com/api/v4/"
-    path = "admin"
-    path = ${?CMWL_GITLAB_USER_NAME}
     token = "token"
     token = ${?CMWL_GITLAB_TOKEN}
     defaultFileVersion = "v0.0.1"

--- a/portal/src/main/scala/cromwell/pipeline/CromwellPipelineApp.scala
+++ b/portal/src/main/scala/cromwell/pipeline/CromwellPipelineApp.scala
@@ -44,6 +44,7 @@ object CromwellPipelineApp extends App {
       userController.route,
       projectController.route,
       projectFileController.route,
+      runController.route,
       configurationController.route
     )
   }

--- a/postman/Files.postman_collection.json
+++ b/postman/Files.postman_collection.json
@@ -51,7 +51,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\r\n    \"project\": {\r\n        \"projectId\": \"\",\r\n        \"ownerId\": \"\",\r\n        \"name\": \"\",\r\n        \"active\": true\r\n    },\r\n    \"projectFile\": {\r\n        \"path\": \"\",\r\n        \"context\": \"{{valid_wdl_file}}\"\r\n    }\r\n}",
+					"raw": "{\r\n    \"project\": {\r\n        \"projectId\": \"\",\r\n        \"ownerId\": \"\",\r\n        \"name\": \"\",\r\n        \"active\": true\r\n    },\r\n    \"projectFile\": {\r\n        \"path\": \"\",\r\n        \"content\": \"{{valid_wdl_file}}\"\r\n    }\r\n}",
 					"options": {
 						"raw": {
 							"language": "json"

--- a/postman/Projects.postman_collection.json
+++ b/postman/Projects.postman_collection.json
@@ -99,7 +99,7 @@
 			"response": []
 		},
 		{
-			"name": "Change project name and repository (optional)",
+			"name": "Change project name",
 			"request": {
 				"method": "PUT",
 				"header": [
@@ -111,7 +111,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\r\n    \"projectId\": \"\",\r\n    \"name\": \"\",\r\n    \"repository\": \"\"\r\n}",
+					"raw": "{\r\n    \"projectId\": \"\",\r\n    \"name\": \"\",\r\n}",
 					"options": {
 						"raw": {
 							"language": "json"

--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/DatastorageModule.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/DatastorageModule.scala
@@ -1,8 +1,7 @@
 package cromwell.pipeline.datastorage
 
 import cromwell.pipeline.database.{ MongoEngine, PipelineDatabaseEngine }
-import cromwell.pipeline.datastorage.dao.ProjectEntry
-import cromwell.pipeline.datastorage.dao.entry.{ RunEntry, UserEntry }
+import cromwell.pipeline.datastorage.dao.entry.{ AliasesSupport, ProjectEntry, RunEntry, UserEntry }
 import cromwell.pipeline.datastorage.dao.repository.{
   DocumentRepository,
   ProjectRepository,
@@ -22,8 +21,8 @@ class DatastorageModule(applicationConfig: ApplicationConfig) {
   lazy val pipelineDatabaseEngine: PipelineDatabaseEngine = new PipelineDatabaseEngine(applicationConfig.config)
   lazy val profile: JdbcProfile = pipelineDatabaseEngine.profile
   lazy val databaseLayer: DatabaseLayer = new DatabaseLayer(profile)
-  lazy val configurationCollection
-    : MongoCollection[Document] = new MongoEngine(applicationConfig.mongoConfig).mongoCollection
+  lazy val configurationCollection: MongoCollection[Document] =
+    new MongoEngine(applicationConfig.mongoConfig).mongoCollection
 
   lazy val userRepository: UserRepository =
     new UserRepository(pipelineDatabaseEngine, databaseLayer)
@@ -58,6 +57,7 @@ trait Profile {
 
 class DatabaseLayer(override val profile: JdbcProfile)
     extends Profile
+    with AliasesSupport
     with UserEntry
     with ProjectEntry
     with CustomsWithEnumSupport

--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/dao/entry/ProjectEntry.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/dao/entry/ProjectEntry.scala
@@ -1,25 +1,25 @@
-package cromwell.pipeline.datastorage.dao
+package cromwell.pipeline.datastorage.dao.entry
 
 import cromwell.pipeline.datastorage.Profile
-import cromwell.pipeline.datastorage.dao.entry.UserEntry
 import cromwell.pipeline.datastorage.dto._
 import cromwell.pipeline.model.wrapper.UserId
+import slick.lifted.{ ForeignKeyQuery, ProvenShape }
 
-trait ProjectEntry { this: Profile with UserEntry with CustomsWithEnumSupport =>
+trait ProjectEntry { this: Profile with UserEntry with CustomsWithEnumSupport with AliasesSupport =>
   import Implicits._
   import api._
 
   class ProjectTable(tag: Tag) extends Table[Project](tag, "project") {
-    def projectId = column[ProjectId]("project_id", O.PrimaryKey)
-    def ownerId = column[UserId]("owner_id")
-    def name = column[String]("name")
-    def active = column[Boolean]("active")
-    def repository = column[Repository]("repository")
-    def visibility = column[Visibility]("visibility")
-    def * = (projectId, ownerId, name, active, repository.?, visibility) <>
+    def projectId: Rep[ProjectId] = column[ProjectId]("project_id", O.PrimaryKey)
+    def ownerId: Rep[UserId] = column[UserId]("owner_id")
+    def name: Rep[String] = column[String]("name")
+    def active: Rep[Boolean] = column[Boolean]("active")
+    def repositoryId: Rep[RepositoryId] = column[RepositoryId]("repository_id")
+    def visibility: Rep[Visibility] = column[Visibility]("visibility")
+    def * : ProvenShape[Project] = (projectId, ownerId, name, active, repositoryId, visibility) <>
       ((Project.apply _).tupled, Project.unapply)
 
-    def user = foreignKey("fk_project_user", ownerId, users)(_.userId)
+    def user: ForeignKeyQuery[UserTable, User] = foreignKey("fk_project_user", ownerId, users)(_.userId)
   }
 
   val projects = TableQuery[ProjectTable]
@@ -32,14 +32,12 @@ trait ProjectEntry { this: Profile with UserEntry with CustomsWithEnumSupport =>
     projects.filter(_.name === name).take(1)
   }
 
-  def addProjectAction(project: Project) = projects.returning(projects.map(_.projectId)) += project
+  def addProjectAction(project: Project): ActionResult[ProjectId] =
+    projects.returning(projects.map(_.projectId)) += project
 
-  def deactivateProjectByIdAction(projectId: ProjectId) =
+  def deactivateProjectByIdAction(projectId: ProjectId): ActionResult[Int] =
     projects.filter(_.projectId === projectId).map(_.active).update(false)
 
-  def updateProjectAction(updatedProject: Project) =
-    projects
-      .filter(_.projectId === updatedProject.projectId)
-      .map(project => (project.name, project.repository.?))
-      .update((updatedProject.name, updatedProject.repository))
+  def updateProjectNameAction(updatedProject: Project): ActionResult[Int] =
+    projects.filter(_.projectId === updatedProject.projectId).map(project => project.name).update(updatedProject.name)
 }

--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/dao/entry/RunEntry.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/dao/entry/RunEntry.scala
@@ -3,29 +3,30 @@ package cromwell.pipeline.datastorage.dao.entry
 import java.time.Instant
 
 import cromwell.pipeline.datastorage.Profile
-import cromwell.pipeline.datastorage.dao.ProjectEntry
-import cromwell.pipeline.datastorage.dto.{ CustomsWithEnumSupport, ProjectId, Run, Status }
+import cromwell.pipeline.datastorage.dto._
 import cromwell.pipeline.model.wrapper.{ RunId, UserId }
+import slick.lifted.{ ForeignKeyQuery, ProvenShape }
 
-trait RunEntry { this: Profile with UserEntry with ProjectEntry with CustomsWithEnumSupport =>
+trait RunEntry { this: Profile with UserEntry with ProjectEntry with CustomsWithEnumSupport with AliasesSupport =>
   import Implicits._
   import api._
 
   class RunTable(tag: Tag) extends Table[Run](tag, "run") {
-    def * = (runId, projectId, projectVersion, status, timeStart, timeEnd.?, userId, results, cmwlWorkflowId.?) <>
-      ((Run.apply _).tupled, Run.unapply)
+    def * : ProvenShape[Run] =
+      (runId, projectId, projectVersion, status, timeStart, timeEnd, userId, results, cmwlWorkflowId) <>
+        ((Run.apply _).tupled, Run.unapply)
 
-    def runId = column[RunId]("run_id", O.PrimaryKey)
-    def projectVersion = column[String]("project_version")
-    def status = column[Status]("status")
-    def timeStart = column[Instant]("time_start")
-    def timeEnd = column[Instant]("time_end")
-    def results = column[String]("results")
-    def cmwlWorkflowId = column[String]("cmwl_workflow_id")
-    def project = foreignKey("fk_run_project", projectId, projects)(_.projectId)
-    def projectId = column[ProjectId]("project_id")
-    def user = foreignKey("fk_run_user", userId, users)(_.userId)
-    def userId = column[UserId]("user_id")
+    def runId: Rep[RunId] = column[RunId]("run_id", O.PrimaryKey)
+    def projectVersion: Rep[String] = column[String]("project_version")
+    def status: Rep[Status] = column[Status]("status")
+    def timeStart: Rep[Instant] = column[Instant]("time_start")
+    def timeEnd: Rep[Option[Instant]] = column[Option[Instant]]("time_end")
+    def results: Rep[String] = column[String]("results")
+    def cmwlWorkflowId: Rep[Option[String]] = column[Option[String]]("cmwl_workflow_id")
+    def projectId: Rep[ProjectId] = column[ProjectId]("project_id")
+    def userId: Rep[UserId] = column[UserId]("user_id")
+    def project: ForeignKeyQuery[ProjectTable, Project] = foreignKey("fk_run_project", projectId, projects)(_.projectId)
+    def user: ForeignKeyQuery[UserTable, User] = foreignKey("fk_run_user", userId, users)(_.userId)
   }
 
   val runs = TableQuery[RunTable]
@@ -33,9 +34,9 @@ trait RunEntry { this: Profile with UserEntry with ProjectEntry with CustomsWith
   def getRunByIdAndUser(runId: RunId, userId: UserId) =
     runs.filter(run => run.runId === runId && run.userId === userId).take(1)
 
-  def deleteRunById(runId: RunId) = runs.filter(_.runId === runId).delete
+  def deleteRunById(runId: RunId): ActionResult[Int] = runs.filter(_.runId === runId).delete
 
-  def updateRun(updatedRun: Run) =
+  def updateRun(updatedRun: Run): ActionResult[Int] =
     runs
       .filter(_.runId === updatedRun.runId)
       .map(run => (run.status, run.timeStart, run.timeEnd, run.results, run.cmwlWorkflowId))
@@ -43,11 +44,11 @@ trait RunEntry { this: Profile with UserEntry with ProjectEntry with CustomsWith
         (
           updatedRun.status,
           updatedRun.timeStart,
-          updatedRun.timeEnd.get,
+          updatedRun.timeEnd,
           updatedRun.results,
-          updatedRun.cmwlWorkflowId.get
+          updatedRun.cmwlWorkflowId
         )
       )
 
-  def addRun(run: Run) = runs.returning(runs.map(_.runId)) += run
+  def addRun(run: Run): ActionResult[RunId] = runs.returning(runs.map(_.runId)) += run
 }

--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/dao/entry/UserEntry.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/dao/entry/UserEntry.scala
@@ -3,24 +3,26 @@ package cromwell.pipeline.datastorage.dao.entry
 import cromwell.pipeline.datastorage.Profile
 import cromwell.pipeline.datastorage.dto._
 import cromwell.pipeline.model.wrapper.{ Name, UserEmail, UserId }
+import slick.lifted.ProvenShape
 
 trait UserEntry {
-  this: Profile =>
+  this: Profile with AliasesSupport =>
 
   import Implicits._
   import profile.api._
 
   class UserTable(tag: Tag) extends Table[User](tag, "user") {
-    def userId = column[UserId]("user_id", O.PrimaryKey)
-    def email = column[UserEmail]("email")
-    def passwordHash = column[String]("password_hash")
-    def passwordSalt = column[String]("password_salt")
-    def firstName = column[Name]("first_name")
-    def lastName = column[Name]("last_name")
-    def profilePicture = column[ProfilePicture]("profile_picture")
-    def active = column[Boolean]("active")
-    def * = (userId, email, passwordHash, passwordSalt, firstName, lastName, profilePicture.?, active) <>
-      ((User.apply _).tupled, User.unapply)
+    def userId: Rep[UserId] = column[UserId]("user_id", O.PrimaryKey)
+    def email: Rep[UserEmail] = column[UserEmail]("email")
+    def passwordHash: Rep[String] = column[String]("password_hash")
+    def passwordSalt: Rep[String] = column[String]("password_salt")
+    def firstName: Rep[Name] = column[Name]("first_name")
+    def lastName: Rep[Name] = column[Name]("last_name")
+    def profilePicture: Rep[ProfilePicture] = column[ProfilePicture]("profile_picture")
+    def active: Rep[Boolean] = column[Boolean]("active")
+    def * : ProvenShape[User] =
+      (userId, email, passwordHash, passwordSalt, firstName, lastName, profilePicture.?, active) <>
+        ((User.apply _).tupled, User.unapply)
   }
 
   val users = TableQuery[UserTable]
@@ -36,19 +38,21 @@ trait UserEntry {
   def getUsersByEmailAction(emailPattern: String) =
     users.filter(_.email.like(emailPattern)).result
 
-  def addUserAction(user: User) = users.returning(users.map(_.userId)) += user
+  def addUserAction(user: User): ActionResult[UserId] = users.returning(users.map(_.userId)) += user
 
-  def deactivateUserByEmail(email: UserEmail) = users.filter(_.email === email).map(_.active).update(false)
+  def deactivateUserByEmail(email: UserEmail): ActionResult[Int] =
+    users.filter(_.email === email).map(_.active).update(false)
 
-  def deactivateUserById(userId: UserId) = users.filter(_.userId === userId).map(_.active).update(false)
+  def deactivateUserById(userId: UserId): ActionResult[Int] =
+    users.filter(_.userId === userId).map(_.active).update(false)
 
-  def updateUser(updatedUser: User) =
+  def updateUser(updatedUser: User): ActionResult[Int] =
     users
       .filter(_.userId === updatedUser.userId)
       .map(user => (user.email, user.firstName, user.lastName))
       .update((updatedUser.email, updatedUser.firstName, updatedUser.lastName))
 
-  def updatePassword(updatedUser: User) =
+  def updatePassword(updatedUser: User): ActionResult[Int] =
     users
       .filter(_.userId === updatedUser.userId)
       .map(user => (user.passwordHash, user.passwordSalt))

--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/dao/entry/package.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/dao/entry/package.scala
@@ -1,0 +1,12 @@
+package cromwell.pipeline.datastorage.dao
+
+import cromwell.pipeline.datastorage.Profile
+import slick.sql.FixedSqlAction
+
+package object entry {
+  trait AliasesSupport { this: Profile =>
+    import profile.api._
+
+    type ActionResult[+T] = FixedSqlAction[T, NoStream, Effect.Write]
+  }
+}

--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/dao/repository/ProjectRepository.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/dao/repository/ProjectRepository.scala
@@ -1,7 +1,7 @@
 package cromwell.pipeline.datastorage.dao.repository
 
 import cromwell.pipeline.database.PipelineDatabaseEngine
-import cromwell.pipeline.datastorage.dao.ProjectEntry
+import cromwell.pipeline.datastorage.dao.entry.ProjectEntry
 import cromwell.pipeline.datastorage.dto.{ Project, ProjectId }
 
 import scala.concurrent.Future
@@ -22,7 +22,7 @@ class ProjectRepository(pipelineDatabaseEngine: PipelineDatabaseEngine, projectE
   def deactivateProjectById(projectId: ProjectId): Future[Int] =
     database.run(projectEntry.deactivateProjectByIdAction(projectId))
 
-  def updateProject(updatedProject: Project): Future[Int] =
-    database.run(projectEntry.updateProjectAction(updatedProject))
+  def updateProjectName(updatedProject: Project): Future[Int] =
+    database.run(projectEntry.updateProjectNameAction(updatedProject))
 
 }

--- a/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/MarshallerTests.scala
+++ b/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/MarshallerTests.scala
@@ -70,9 +70,9 @@ class MarshallerTests extends AsyncWordSpec with Matchers with ScalaCheckDrivenP
       }
     }
     "format ProjectUpdateRequest" in {
-      forAll { (a: ProjectUpdateRequest) =>
-        val parseResult: ProjectUpdateRequest =
-          projectUpdateRequestFormat.reads(projectUpdateRequestFormat.writes(a)) match {
+      forAll { (a: ProjectUpdateNameRequest) =>
+        val parseResult: ProjectUpdateNameRequest =
+          projectUpdateNameRequestFormat.reads(projectUpdateNameRequestFormat.writes(a)) match {
             case JsSuccess(value, _) => value
             case JsError(_)          => fail("Could not parse request")
           }

--- a/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/UserRepositoryTest.scala
+++ b/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/UserRepositoryTest.scala
@@ -23,7 +23,6 @@ class UserRepositoryTest extends AsyncWordSpec with Matchers with BeforeAndAfter
   }
 
   private val newPasswordHash: String = StringUtils.calculatePasswordHash("newPassword1", "salt")
-  private val newInvalidPasswordHash: String = StringUtils.calculatePasswordHash("newPassword", "salt")
 
   "UserRepository" when {
 

--- a/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/utils/ArbitraryUtils.scala
+++ b/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/utils/ArbitraryUtils.scala
@@ -14,7 +14,8 @@ object ArbitraryUtils {
   implicit def arbitrarySignInRequest: Arbitrary[SignInRequest] = Arbitrary(signInRequestGen)
   implicit def arbitraryProjectAdditionRequest: Arbitrary[ProjectAdditionRequest] = Arbitrary(projectAdditionRequestGen)
   implicit def arbitraryProjectDeleteRequest: Arbitrary[ProjectDeleteRequest] = Arbitrary(projectDeleteRequestGen)
-  implicit def arbitraryProjectUpdateRequest: Arbitrary[ProjectUpdateRequest] = Arbitrary(projectUpdateRequestGen)
+  implicit def arbitraryProjectUpdateNameRequest: Arbitrary[ProjectUpdateNameRequest] =
+    Arbitrary(projectUpdateNameRequestGen)
   implicit def arbitraryProjectFileContent: Arbitrary[ProjectFileContent] = Arbitrary(projectFileContentGen)
   implicit def arbitraryProjectUpdateFileRequest: Arbitrary[ProjectUpdateFileRequest] = Arbitrary(
     projectUpdateFileRequestGen

--- a/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/utils/FormatUtils.scala
+++ b/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/utils/FormatUtils.scala
@@ -12,7 +12,7 @@ object FormatUtils {
   implicit val signInRequestFormat: Format[SignInRequest] = SignInRequest.signInRequestFormat
   implicit val projectAdditionRequestFormat: Format[ProjectAdditionRequest] = ProjectAdditionRequest.projectAdditionFormat
   implicit val projectDeleteRequestFormat: Format[ProjectDeleteRequest] = ProjectDeleteRequest.projectDeleteFormat
-  implicit val projectUpdateRequestFormat: Format[ProjectUpdateRequest] = ProjectUpdateRequest.updateRequestFormat
+  implicit val projectUpdateNameRequestFormat: Format[ProjectUpdateNameRequest] = ProjectUpdateNameRequest.updateRequestFormat
   implicit val projectFileContentFormat: Format[ProjectFileContent] = ProjectFileContent.projectFileContentFormat
   implicit val projectUpdateFileRequestFormat: Format[ProjectUpdateFileRequest] = ProjectUpdateFileRequest.projectUpdateFileRequestFormat
   implicit val projectBuildConfigurationRequestFormat: Format[ProjectBuildConfigurationRequest] =

--- a/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/utils/TestProjectUtils.scala
+++ b/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/utils/TestProjectUtils.scala
@@ -9,19 +9,27 @@ import scala.util.Random
 
 object TestProjectUtils {
 
-  private val defaultRange: Int = 12
+  private val defaultRange: Int = 100
   private def randomInt(range: Int = defaultRange): Int = Random.nextInt(range)
   private def randomUuidStr: String = UUID.randomUUID().toString
   def getDummyProjectId: ProjectId = ProjectId(randomUuidStr)
-  def getDummyRepository: Repository = Repository(s"repo-$randomUuidStr")
+  def getDummyRepositoryId: RepositoryId = RepositoryId(randomInt())
   def getDummyProject(
     projectId: ProjectId = getDummyProjectId,
     ownerId: UserId = TestUserUtils.getDummyUserId,
     name: String = s"project-$randomUuidStr",
-    repository: Option[Repository] = Some(getDummyRepository),
+    repository: RepositoryId = getDummyRepositoryId,
     active: Boolean = true,
     visibility: Visibility = Private
   ): Project = Project(projectId, ownerId, name, active, repository, visibility)
+  def getDummyLocalProject(
+    projectId: ProjectId = getDummyProjectId,
+    ownerId: UserId = TestUserUtils.getDummyUserId,
+    name: String = s"project-$randomUuidStr",
+    active: Boolean = true,
+    visibility: Visibility = Private
+  ): LocalProject =
+    LocalProject(projectId, ownerId, name, active, visibility)
   def getDummyCommit(id: String = randomUuidStr): Commit = Commit(id)
   def getDummyPipeLineVersion(
     v1: Int = 1 + randomInt(),
@@ -29,9 +37,9 @@ object TestProjectUtils {
     v3: Int = 1 + randomInt()
   ): PipelineVersion =
     PipelineVersion(s"v$v1.$v2.$v3")
-  def getDummyRepositoryId(
-    id: Int = randomInt()
-  ): RepositoryId = RepositoryId(id)
+  def getDummyGitLabRepositoryResponse(
+    repositoryId: RepositoryId = getDummyRepositoryId
+  ): GitLabRepositoryResponse = GitLabRepositoryResponse(repositoryId)
   def getDummyGitLabVersion(
     version: PipelineVersion = getDummyPipeLineVersion(),
     message: String = s"message-$randomUuidStr",

--- a/services/src/main/scala/cromwell/pipeline/service/GitLabProjectVersioning.scala
+++ b/services/src/main/scala/cromwell/pipeline/service/GitLabProjectVersioning.scala
@@ -1,11 +1,10 @@
 package cromwell.pipeline.service
 
-import java.net.URLEncoder
 import java.nio.file.Path
 
 import cromwell.pipeline.datastorage.dto.File.UpdateFileRequest
 import cromwell.pipeline.datastorage.dto._
-import cromwell.pipeline.utils.{ GitLabConfig, HttpStatusCodes }
+import cromwell.pipeline.utils.{ GitLabConfig, HttpStatusCodes, URLEncoderUtils }
 
 import scala.concurrent.{ ExecutionContext, Future }
 
@@ -26,13 +25,15 @@ class GitLabProjectVersioning(httpClient: HttpClient, config: GitLabConfig)
   ): Either[VersioningException, PipelineVersion] =
     (optionProjectVersion, optionUserVersion) match {
       case (Some(projectVersion), Some(userVersion)) =>
-        if (projectVersion >= userVersion)
-          Left(
-            VersioningException.ProjectException(
+        if (projectVersion >= userVersion) {
+          Left {
+            VersioningException.ProjectException {
               s"Your version $userVersion is out of date. Current version of project: $projectVersion"
-            )
-          )
-        else Right(userVersion)
+            }
+          }
+        } else {
+          Right(userVersion)
+        }
       case (Some(projectVersion), None) => Right(projectVersion.increaseRevision)
       case (None, Some(userVersion))    => Right(userVersion)
       case (None, None) =>
@@ -44,7 +45,7 @@ class GitLabProjectVersioning(httpClient: HttpClient, config: GitLabConfig)
     }
 
   private def handleCreateTag(
-    repositoryId: Repository,
+    repositoryId: RepositoryId,
     version: PipelineVersion,
     responseBody: SuccessResponseMessage
   )(
@@ -58,11 +59,8 @@ class GitLabProjectVersioning(httpClient: HttpClient, config: GitLabConfig)
   override def updateFile(project: Project, projectFile: ProjectFile, userVersion: Option[PipelineVersion])(
     implicit ec: ExecutionContext
   ): AsyncResult[SuccessResponseMessage] = {
-    val path = URLEncoder.encode(projectFile.path.toString, "UTF-8")
-    val repositoryId: Repository =
-      project.repository.getOrElse(
-        throw VersioningException.RepositoryException(s"No repository for project: $project")
-      )
+    val path = URLEncoderUtils.encode(projectFile.path.toString)
+    val repositoryId: RepositoryId = project.repositoryId
     val fileUrl = s"${config.url}projects/${repositoryId.value}/repository/files/$path"
 
     getLastProjectVersion(project).map(projectVersion => getNewProjectVersion(projectVersion, userVersion)).flatMap {
@@ -88,10 +86,10 @@ class GitLabProjectVersioning(httpClient: HttpClient, config: GitLabConfig)
     }
   }
 
-  private def createTag(projectId: Repository, version: PipelineVersion)(
+  private def createTag(repositoryId: RepositoryId, version: PipelineVersion)(
     implicit ec: ExecutionContext
   ): AsyncResult[SuccessResponseMessage] = {
-    val tagUrl = s"${config.url}projects/${projectId.value}/repository/tags"
+    val tagUrl = s"${config.url}projects/${repositoryId.value}/repository/tags"
     httpClient
       .post[SuccessResponseMessage, EmptyPayload](
         tagUrl,
@@ -109,17 +107,17 @@ class GitLabProjectVersioning(httpClient: HttpClient, config: GitLabConfig)
     implicit ec: ExecutionContext
   ): AsyncResult[List[SuccessResponseMessage]] = ???
 
-  override def createRepository(project: Project)(implicit ec: ExecutionContext): AsyncResult[Project] =
-    if (!project.active)
+  override def createRepository(localProject: LocalProject)(implicit ec: ExecutionContext): AsyncResult[Project] =
+    if (!localProject.active) {
       Future.failed(VersioningException.RepositoryException("Could not create a repository for deleted project."))
-    else {
+    } else {
       val createRepoUrl: String = s"${config.url}projects"
-      val postProject = PostProject(name = project.name)
+      val postProject = PostProject(name = localProject.name)
       httpClient
-        .post[RepositoryId, PostProject](url = createRepoUrl, headers = config.token, payload = postProject)
+        .post[GitLabRepositoryResponse, PostProject](url = createRepoUrl, headers = config.token, payload = postProject)
         .map {
-          case Response(_, SuccessResponseBody(gitLabProject), _) =>
-            Right(project.withRepository(Some(s"${config.idPath}${gitLabProject.id}")))
+          case Response(_, SuccessResponseBody(gitLabResponse), _) =>
+            Right(localProject.toProject(gitLabResponse.id))
           case Response(statusCode, FailureResponseBody(error), _) =>
             Left {
               VersioningException.RepositoryException {
@@ -133,7 +131,7 @@ class GitLabProjectVersioning(httpClient: HttpClient, config: GitLabConfig)
   override def getFiles(project: Project, path: Path)(implicit ec: ExecutionContext): AsyncResult[List[String]] = ???
 
   override def getProjectVersions(project: Project)(implicit ec: ExecutionContext): AsyncResult[Seq[GitLabVersion]] = {
-    val versionsListUrl: String = s"${config.url}projects/${project.repository.get.value}/repository/tags"
+    val versionsListUrl: String = s"${config.url}projects/${project.repositoryId.value}/repository/tags"
     httpClient
       .get[Seq[GitLabVersion]](url = versionsListUrl, headers = config.token)
       .map {
@@ -142,7 +140,7 @@ class GitLabProjectVersioning(httpClient: HttpClient, config: GitLabConfig)
         case Response(_, FailureResponseBody(error), _) =>
           Left(
             VersioningException.ProjectException(
-              s"Could not take versions. ResponseBody: ${error}"
+              s"Could not take versions. ResponseBody: $error"
             )
           )
       }
@@ -152,15 +150,15 @@ class GitLabProjectVersioning(httpClient: HttpClient, config: GitLabConfig)
   override def getFileCommits(project: Project, path: Path)(
     implicit ec: ExecutionContext
   ): AsyncResult[Seq[FileCommit]] = {
-    val urlEncoder = URLEncoder.encode(path.toString, "UTF-8")
+    val urlEncoder = URLEncoderUtils.encode(path.toString)
     val commitsUrl: String =
-      s"${config.url}projects/${project.repository.get.value}/repository/files/${urlEncoder}"
+      s"${config.url}projects/${project.repositoryId.value}/repository/files/$urlEncoder"
     httpClient.get[List[FileCommit]](url = commitsUrl, headers = config.token).map {
       case Response(_, SuccessResponseBody(commitsSeq), _) => Right(commitsSeq)
       case Response(_, FailureResponseBody(error), _) =>
         Left(
           VersioningException.FileException(
-            s"Could not take the file commits. ResponseBody: ${error}"
+            s"Could not take the file commits. ResponseBody: $error"
           )
         )
     }
@@ -200,7 +198,7 @@ class GitLabProjectVersioning(httpClient: HttpClient, config: GitLabConfig)
       case None          => Map()
     }
     val filesTreeUrl: String =
-      s"${config.url}projects/${project.repository.get.value}/repository/tree"
+      s"${config.url}projects/${project.repositoryId.value}/repository/tree"
 
     httpClient
       .get[List[FileTree]](url = filesTreeUrl, params = versionId, headers = config.token)
@@ -209,7 +207,7 @@ class GitLabProjectVersioning(httpClient: HttpClient, config: GitLabConfig)
         case Response(statusCode, FailureResponseBody(error), _) =>
           Left(
             VersioningException.FileException(
-              s"Could not take the files tree or parse json. Response status: ${statusCode}. ResponseBody: ${error}"
+              s"Could not take the files tree or parse json. Response status: $statusCode. ResponseBody: $error"
             )
           )
       }
@@ -220,7 +218,7 @@ class GitLabProjectVersioning(httpClient: HttpClient, config: GitLabConfig)
   override def getFile(project: Project, path: Path, version: Option[PipelineVersion])(
     implicit ec: ExecutionContext
   ): AsyncResult[ProjectFile] = {
-    val filePath: String = URLEncoder.encode(path.toString, "UTF-8")
+    val filePath: String = URLEncoderUtils.encode(path.toString)
     val fileVersion: String = version match {
       case Some(version) => version.name
       case None          => config.defaultFileVersion
@@ -228,7 +226,7 @@ class GitLabProjectVersioning(httpClient: HttpClient, config: GitLabConfig)
 
     httpClient
       .get[ProjectFileContent](
-        s"${config.url}/projects/${project.repository}/repository/files/$filePath/raw",
+        s"${config.url}/projects/${project.repositoryId.value}/repository/files/$filePath/raw",
         Map("ref" -> fileVersion),
         config.token
       )
@@ -238,11 +236,11 @@ class GitLabProjectVersioning(httpClient: HttpClient, config: GitLabConfig)
         case Response(HttpStatusCodes.OK, FailureResponseBody(error), _) =>
           Left(
             VersioningException.HttpException(
-              s"Could not take Project File. Response status: ${HttpStatusCodes.OK}. ResponseBody: ${error}"
+              s"Could not take Project File. Response status: ${HttpStatusCodes.OK}. ResponseBody: $error"
             )
           )
         case Response(responseStatus, _, _) =>
-          Left(VersioningException.HttpException(s"Exception. Response status: ${responseStatus}"))
+          Left(VersioningException.HttpException(s"Exception. Response status: $responseStatus"))
       }
       .recover { case e: Throwable => Left(VersioningException.HttpException(e.getMessage)) }
   }

--- a/services/src/main/scala/cromwell/pipeline/service/ProjectService.scala
+++ b/services/src/main/scala/cromwell/pipeline/service/ProjectService.scala
@@ -27,16 +27,16 @@ class ProjectService(projectRepository: ProjectRepository, projectVersioning: Pr
     }
 
   def addProject(request: ProjectAdditionRequest, userId: UserId): Future[Either[VersioningException, ProjectId]] = {
-    val project =
-      Project(
+    val localProject =
+      LocalProject(
         projectId = ProjectId(UUID.randomUUID().toString),
         ownerId = userId,
         name = request.name,
         active = true
       )
-    projectVersioning.createRepository(project).flatMap {
-      case Left(exception)       => Future.successful(Left(exception))
-      case Right(value: Project) => projectRepository.addProject(value).map(Right(_))
+    projectVersioning.createRepository(localProject).flatMap {
+      case Left(exception) => Future.successful(Left(exception))
+      case Right(project)  => projectRepository.addProject(project).map(Right(_))
     }
   }
 
@@ -49,9 +49,9 @@ class ProjectService(projectRepository: ProjectRepository, projectVersioning: Pr
       }
     }
 
-  def updateProject(request: ProjectUpdateRequest, userId: UserId): Future[Int] =
+  def updateProjectName(request: ProjectUpdateNameRequest, userId: UserId): Future[Int] =
     getUserProjectById(request.projectId, userId).flatMap { project =>
-      projectRepository.updateProject(project.copy(name = request.name, repository = request.repository))
+      projectRepository.updateProjectName(project.copy(name = request.name))
     }
 
 }

--- a/services/src/main/scala/cromwell/pipeline/service/ProjectVersioning.scala
+++ b/services/src/main/scala/cromwell/pipeline/service/ProjectVersioning.scala
@@ -2,15 +2,7 @@ package cromwell.pipeline.service
 
 import java.nio.file.Path
 
-import cromwell.pipeline.datastorage.dto.{
-  FileCommit,
-  FileTree,
-  GitLabVersion,
-  PipelineVersion,
-  Project,
-  ProjectFile,
-  SuccessResponseMessage
-}
+import cromwell.pipeline.datastorage.dto._
 
 import scala.concurrent.{ ExecutionContext, Future }
 
@@ -26,7 +18,7 @@ trait ProjectVersioning[E >: VersioningException] {
     implicit ec: ExecutionContext
   ): AsyncResult[List[SuccessResponseMessage]]
 
-  def createRepository(project: Project)(
+  def createRepository(localProject: LocalProject)(
     implicit ec: ExecutionContext
   ): AsyncResult[Project]
 

--- a/services/src/test/resources/application.conf
+++ b/services/src/test/resources/application.conf
@@ -1,7 +1,6 @@
   database {
       gitlab {
         url = "https://gitlab.com/api/v4/"
-        path = "AdminLogin" //TODO: Change AdminLogin for real GitLab login
         token = "XXXX" //TODO: Change for real GitLab private token
         defaultFileVersion = "v.0.0.1"
         defaultBranch = "master"

--- a/services/src/test/scala/cromwell/pipeline/service/GitLabProjectVersioningTest.scala
+++ b/services/src/test/scala/cromwell/pipeline/service/GitLabProjectVersioningTest.scala
@@ -1,15 +1,14 @@
 package cromwell.pipeline.service
 
-import java.net.URLEncoder
 import java.nio.file.{ Path, Paths }
 
 import akka.http.scaladsl.model.StatusCodes
 import cromwell.pipeline.datastorage.dao.repository.utils.TestProjectUtils
 import cromwell.pipeline.datastorage.dto.File.UpdateFileRequest
 import cromwell.pipeline.datastorage.dto._
-import cromwell.pipeline.utils.{ AkkaTestSources, ApplicationConfig, GitLabConfig, HttpStatusCodes }
+import cromwell.pipeline.utils._
+import org.mockito.Matchers.{ any, eq => exact }
 import org.mockito.Mockito.when
-import org.mockito.{ Matchers => MockitoMatchers }
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{ AsyncWordSpec, Matchers }
 import org.scalatestplus.mockito.MockitoSugar
@@ -46,50 +45,48 @@ class GitLabProjectVersioningTest
 
     "createRepository" should {
 
-      def request(postProject: PostProject) =
-        mockHttpClient.post[RepositoryId, PostProject](
+      def request(postProject: PostProject): Future[Response[GitLabRepositoryResponse]] =
+        mockHttpClient.post[GitLabRepositoryResponse, PostProject](
           url = gitLabConfig.url + "projects",
           headers = gitLabConfig.token,
           payload = postProject
         )
 
       "throw new VersioningException for inactive project" taggedAs Service in {
-        whenReady(gitLabProjectVersioning.createRepository(inactiveProject).failed) {
+        whenReady(gitLabProjectVersioning.createRepository(inactiveLocalProject).failed) {
           _ shouldBe VersioningException.RepositoryException("Could not create a repository for deleted project.")
         }
       }
 
       "return new active Project with 201 response" taggedAs Service in {
 
-        val project = withGitlabProject
-
-        when(request(postProject)).thenReturn(
-          Future.successful(
-            Response[RepositoryId](
+        when(request(postProject)).thenReturn {
+          Future.successful {
+            Response[GitLabRepositoryResponse](
               HttpStatusCodes.Created,
-              SuccessResponseBody[RepositoryId](repositoryId),
+              SuccessResponseBody[GitLabRepositoryResponse](gitLabRepositoryResponse),
               EmptyHeaders
             )
-          )
-        )
+          }
+        }
 
-        gitLabProjectVersioning.createRepository(activeProject).map {
-          _ shouldBe Right(project)
+        gitLabProjectVersioning.createRepository(activeLocalProject).map {
+          _ shouldBe Right(activeProject)
         }
       }
 
       "throw new VersioningException with 400 response" taggedAs Service in {
         val errorMsg = "The repository was not created. Response status: 400"
-        when(request(postProject)).thenReturn(
-          Future.successful(
-            Response[RepositoryId](
+        when(request(postProject)).thenReturn {
+          Future.successful {
+            Response[GitLabRepositoryResponse](
               HttpStatusCodes.BadRequest,
               FailureResponseBody(errorMsg),
               EmptyHeaders
             )
-          )
-        )
-        gitLabProjectVersioning.createRepository(activeProject).map {
+          }
+        }
+        gitLabProjectVersioning.createRepository(activeLocalProject).map {
           _ shouldBe Left {
             VersioningException.RepositoryException {
               s"The repository was not created. Response status: 400; Response body [$errorMsg]"
@@ -100,49 +97,43 @@ class GitLabProjectVersioningTest
     }
 
     "getProjectVersions" should {
-      def request(project: Project) =
+      def request(project: Project): Future[Response[Seq[GitLabVersion]]] =
         mockHttpClient.get[Seq[GitLabVersion]](
-          url = MockitoMatchers.eq(gitLabConfig.url + "projects/" + project.repository.get.value + "/repository/tags"),
-          headers = MockitoMatchers.any[Map[String, String]],
-          params = MockitoMatchers.any[Map[String, String]]
-        )(MockitoMatchers.any[ExecutionContext], MockitoMatchers.any[Reads[Seq[GitLabVersion]]])
+          url = exact(gitLabConfig.url + "projects/" + project.repositoryId.value + "/repository/tags"),
+          headers = any[Map[String, String]],
+          params = any[Map[String, String]]
+        )(any[ExecutionContext], any[Reads[Seq[GitLabVersion]]])
 
       "return list of Project versions with 200 response" taggedAs Service in {
-        when(request(withRepoProject)).thenReturn(
-          Future.successful(
+        when(request(projectWithRepo)).thenReturn {
+          Future.successful {
             Response[Seq[GitLabVersion]](
               HttpStatusCodes.OK,
               SuccessResponseBody[Seq[GitLabVersion]](dummyVersions),
               EmptyHeaders
             )
-          )
-        )
-        gitLabProjectVersioning.getProjectVersions(withRepoProject).map {
+          }
+        }
+        gitLabProjectVersioning.getProjectVersions(projectWithRepo).map {
           _ shouldBe Right(dummyVersions)
         }
       }
 
       "throw new VersioningException with 400 response" taggedAs Service in {
         val activeProject: Project = TestProjectUtils.getDummyProject()
-        val withRepoProject: Project =
-          activeProject.withRepository(Some(s"${gitLabConfig.idPath}${activeProject.projectId.value}"))
-        when(
-          request(
-            withRepoProject.withRepository(Some(s"${gitLabConfig.idPath}${activeProject.projectId.value}"))
-          )
-        ).thenReturn(
-          Future.successful(
+        when(request(activeProject)).thenReturn {
+          Future.successful {
             Response[Seq[GitLabVersion]](
               HttpStatusCodes.BadRequest,
               FailureResponseBody("Response status: 400"),
               EmptyHeaders
             )
-          )
-        )
-        gitLabProjectVersioning.getProjectVersions(withRepoProject).map {
-          _ shouldBe Left(
+          }
+        }
+        gitLabProjectVersioning.getProjectVersions(activeProject).map {
+          _ shouldBe Left {
             VersioningException.ProjectException("Could not take versions. ResponseBody: Response status: 400")
-          )
+          }
         }
       }
     }
@@ -150,67 +141,67 @@ class GitLabProjectVersioningTest
     "updateFile" should {
       val successUpdateMessage = "File was updated"
       val successCreateMessage = "File was created"
-      val tagUrl = s"${gitLabConfig.url}projects/${withRepoProject.repository.get.value}/repository/tags"
+      val tagUrl = s"${gitLabConfig.url}projects/${projectWithRepo.repositoryId.value}/repository/tags"
       val gitlabVersion = TestProjectUtils.getDummyGitLabVersion(dummyPipelineVersion)
-      when(
+      when {
         mockHttpClient.post[SuccessResponseMessage, PipelineVersion](
-          tagUrl,
+          url = tagUrl,
           params = Map("tag_name" -> dummyPipelineVersionHigher.name, "ref" -> gitLabConfig.defaultBranch),
           headers = gitLabConfig.token,
           payload = dummyPipelineVersion
         )
-      ).thenReturn(
-        Future.successful(
+      }.thenReturn {
+        Future.successful {
           Response[SuccessResponseMessage](
             StatusCodes.OK.intValue,
             SuccessResponseBody(SuccessResponseMessage("Tag was created")),
             EmptyHeaders
           )
-        )
-      )
+        }
+      }
 
       "return create file response when file is new" taggedAs Service in {
-        val path = URLEncoder.encode(newFile.path.toString, "UTF-8")
-        val url = s"${gitLabConfig.url}projects/${withRepoProject.repository.get.value}/repository/files/$path"
+        val path = URLEncoderUtils.encode(newFile.path.toString)
+        val url = s"${gitLabConfig.url}projects/${projectWithRepo.repositoryId.value}/repository/files/$path"
         val payload =
           File.UpdateFileRequest(newFile.content, dummyPipelineVersionHigher.name, gitLabConfig.defaultBranch)
 
-        when(
+        when {
           mockHttpClient.get[List[GitLabVersion]](
-            tagUrl,
+            url = tagUrl,
             headers = gitLabConfig.token
           )
-        ).thenReturn(
-          Future.successful(
+        }.thenReturn {
+          Future.successful {
             Response[List[GitLabVersion]](
               StatusCodes.OK.intValue,
               SuccessResponseBody(List(gitlabVersion)),
               EmptyHeaders
             )
-          )
-        )
-        when(
+          }
+        }
+        when {
           mockHttpClient.put[SuccessResponseMessage, UpdateFileRequest](
-            url,
+            url = url,
             headers = gitLabConfig.token,
             payload = payload
           )
-        ).thenReturn(
-          Future.successful(
+        }.thenReturn {
+          Future.successful {
             Response[SuccessResponseMessage](
               StatusCodes.BadRequest.intValue,
               FailureResponseBody("File does not exist"),
               EmptyHeaders
             )
-          )
-        )
-        when(
+          }
+        }
+        when {
           mockHttpClient.post[SuccessResponseMessage, UpdateFileRequest](
-            url,
+            url = url,
             headers = gitLabConfig.token,
             payload = payload
           )
-        ).thenReturn(
+        }.thenReturn {
           Future.successful(
             Response[SuccessResponseMessage](
               StatusCodes.OK.intValue,
@@ -218,25 +209,25 @@ class GitLabProjectVersioningTest
               EmptyHeaders
             )
           )
-        )
-        when(
+        }
+        when {
           mockHttpClient.post[SuccessResponseMessage, EmptyPayload](
-            tagUrl,
+            url = tagUrl,
             params = Map("tag_name" -> dummyPipelineVersionHigher.name, "ref" -> gitLabConfig.defaultBranch),
             headers = gitLabConfig.token,
             payload = EmptyPayload()
           )
-        ).thenReturn(
-          Future.successful(
+        }.thenReturn {
+          Future.successful {
             Response[SuccessResponseMessage](
               StatusCodes.OK.intValue,
               SuccessResponseBody(SuccessResponseMessage(successCreateMessage)),
               EmptyHeaders
             )
-          )
-        )
+          }
+        }
 
-        gitLabProjectVersioning.updateFile(withRepoProject, newFile, Some(dummyPipelineVersionHigher)).map {
+        gitLabProjectVersioning.updateFile(projectWithRepo, newFile, Some(dummyPipelineVersionHigher)).map {
           _ shouldBe Right(SuccessResponseMessage(successCreateMessage))
         }
       }
@@ -244,75 +235,78 @@ class GitLabProjectVersioningTest
       "return update file response when file is already exist" taggedAs Service in {
         val payload =
           File.UpdateFileRequest(existFile.content, dummyPipelineVersionHigher.name, gitLabConfig.defaultBranch)
-        val path = URLEncoder.encode(existFile.path.toString, "UTF-8")
+        val path = URLEncoderUtils.encode(existFile.path.toString)
         val url =
-          s"${gitLabConfig.url}projects/${withRepoProject.repository.get.value}/repository/files/$path"
-        when(mockHttpClient.get[List[GitLabVersion]](tagUrl, headers = gitLabConfig.token)).thenReturn(
-          Future.successful(
+          s"${gitLabConfig.url}projects/${projectWithRepo.repositoryId.value}/repository/files/$path"
+        when(mockHttpClient.get[List[GitLabVersion]](tagUrl, headers = gitLabConfig.token)).thenReturn {
+          Future.successful {
             Response[List[GitLabVersion]](
               StatusCodes.OK.intValue,
               SuccessResponseBody(List(gitlabVersion)),
               EmptyHeaders
             )
-          )
-        )
-        when(
+          }
+        }
+        when {
           mockHttpClient.put[SuccessResponseMessage, UpdateFileRequest](
-            url,
-            payload = payload,
-            headers = gitLabConfig.token
+            url = url,
+            headers = gitLabConfig.token,
+            payload = payload
           )
-        ).thenReturn(
-          Future.successful(
+        }.thenReturn {
+          Future.successful {
             Response[SuccessResponseMessage](
               StatusCodes.OK.intValue,
               SuccessResponseBody(SuccessResponseMessage(successUpdateMessage)),
               EmptyHeaders
             )
-          )
-        )
-        gitLabProjectVersioning.updateFile(withRepoProject, existFile, Some(dummyPipelineVersionHigher)).map {
+          }
+        }
+        gitLabProjectVersioning.updateFile(projectWithRepo, existFile, Some(dummyPipelineVersionHigher)).map {
           _ shouldBe Right(SuccessResponseMessage(successUpdateMessage))
         }
-        assert(true)
       }
     }
 
     "getFile" should {
       "return file with 200 response" taggedAs Service in {
         val path = Paths.get("test.md")
-
-        when(
+        val encodedPathStr = URLEncoderUtils.encode(path.toString)
+        when {
           mockHttpClient.get[ProjectFileContent](
-            s"${gitLabConfig.url}/projects/${activeProject.repository}/repository/files/${URLEncoder
-              .encode(path.toString, "UTF-8")}/raw",
+            s"${gitLabConfig.url}/projects/${activeProject.repositoryId.value}/repository/files/$encodedPathStr/raw",
             Map("ref" -> dummyPipelineVersion.name),
             gitLabConfig.token
           )
-        ).thenReturn(
-          Future.successful(
-            Response[ProjectFileContent](200, SuccessResponseBody(ProjectFileContent("Test File")), EmptyHeaders)
-          )
-        )
+        }.thenReturn {
+          Future.successful {
+            Response[ProjectFileContent](
+              HttpStatusCodes.OK,
+              SuccessResponseBody(ProjectFileContent("Test File")),
+              EmptyHeaders
+            )
+          }
+        }
 
         gitLabProjectVersioning
           .getFile(activeProject, path, Some(dummyPipelineVersion))
-          .map(_ shouldBe (Right(ProjectFile(path, ProjectFileContent("Test File")))))
+          .map(_ shouldBe Right(ProjectFile(path, ProjectFileContent("Test File"))))
       }
 
       "throw new VersioningException with not 200 response" taggedAs Service in {
         val path = Paths.get("test.md")
-
-        when(
+        val encodedPathStr = URLEncoderUtils.encode(path.toString)
+        when {
           mockHttpClient.get[ProjectFileContent](
-            s"${gitLabConfig.url}/projects/${activeProject.repository}/repository/files/${URLEncoder
-              .encode(path.toString, "UTF-8")}/raw",
+            s"${gitLabConfig.url}/projects/${activeProject.repositoryId.value}/repository/files/$encodedPathStr/raw",
             Map("ref" -> dummyPipelineVersion.name),
             gitLabConfig.token
           )
-        ).thenReturn(
-          Future.successful(Response[ProjectFileContent](404, FailureResponseBody("Not Found"), EmptyHeaders))
-        )
+        }.thenReturn {
+          Future.successful {
+            Response[ProjectFileContent](HttpStatusCodes.NotFound, FailureResponseBody("Not Found"), EmptyHeaders)
+          }
+        }
 
         gitLabProjectVersioning
           .getFile(activeProject, path, Some(dummyPipelineVersion))
@@ -323,32 +317,30 @@ class GitLabProjectVersioningTest
     "getFileCommits" should {
       val dummyCommitList = List(dummyFileCommit)
       val path: Path = Paths.get("tmp/foo.txt")
-      val urlEncoder = URLEncoder.encode(path.toString, "UTF-8")
-      def request(project: Project) =
+      val urlEncoder = URLEncoderUtils.encode(path.toString)
+      def request(project: Project): Future[Response[List[FileCommit]]] =
         mockHttpClient.get[List[FileCommit]](
-          url = MockitoMatchers.eq(
-            s"${gitLabConfig.url}projects/${project.repository.get.value}/repository/files/${urlEncoder}"
-          ),
-          params = MockitoMatchers.any[Map[String, String]],
-          headers = MockitoMatchers.eq(gitLabConfig.token)
-        )(ec = MockitoMatchers.any[ExecutionContext], f = MockitoMatchers.any[Reads[List[FileCommit]]])
+          url = exact(s"${gitLabConfig.url}projects/${project.repositoryId.value}/repository/files/$urlEncoder"),
+          params = any[Map[String, String]],
+          headers = exact(gitLabConfig.token)
+        )(ec = any[ExecutionContext], f = any[Reads[List[FileCommit]]])
 
       "return list of Project versions with 200 response" taggedAs Service in {
-        when(request(withRepoProject)).thenReturn(
+        when(request(projectWithRepo)).thenReturn {
           Future.successful(Response[List[FileCommit]](HttpStatusCodes.OK, SuccessResponseBody(dummyCommitList), Map()))
-        )
-        gitLabProjectVersioning.getFileCommits(withRepoProject, path).map {
+        }
+        gitLabProjectVersioning.getFileCommits(projectWithRepo, path).map {
           _ shouldBe Right(Seq(dummyFileCommit))
         }
       }
 
       "throw new VersioningException with 400 response" taggedAs Service in {
-        when(request(withRepoProject)).thenReturn(
-          Future.successful(
+        when(request(projectWithRepo)).thenReturn {
+          Future.successful {
             Response[List[FileCommit]](HttpStatusCodes.BadRequest, FailureResponseBody("Response status: 400"), Map())
-          )
-        )
-        gitLabProjectVersioning.getFileCommits(withRepoProject, path).map {
+          }
+        }
+        gitLabProjectVersioning.getFileCommits(projectWithRepo, path).map {
           _ shouldBe Left(
             VersioningException.FileException("Could not take the file commits. ResponseBody: Response status: 400")
           )
@@ -360,55 +352,51 @@ class GitLabProjectVersioningTest
       val dummyCommitJson = List(dummyFileCommit, dummyExistingFileCommit)
       val dummyVersionsJson = dummyGitLabVersion
       val path: Path = Paths.get("tmp/foo.txt")
-      val urlEncoder = URLEncoder.encode(path.toString, "UTF-8")
-      def projectVersionRequest(project: Project) =
+      val urlEncoder = URLEncoderUtils.encode(path.toString)
+      def projectVersionRequest(project: Project): Future[Response[Seq[GitLabVersion]]] =
         mockHttpClient.get[Seq[GitLabVersion]](
-          url = MockitoMatchers.eq(
-            s"${gitLabConfig.url}projects/${project.repository.get.value}/repository/tags"
-          ),
-          params = MockitoMatchers.any[Map[String, String]],
-          headers = MockitoMatchers.eq(gitLabConfig.token)
-        )(ec = MockitoMatchers.any[ExecutionContext], f = MockitoMatchers.any[Reads[Seq[GitLabVersion]]])
+          url = exact(s"${gitLabConfig.url}projects/${project.repositoryId.value}/repository/tags"),
+          params = any[Map[String, String]],
+          headers = exact(gitLabConfig.token)
+        )(ec = any[ExecutionContext], f = any[Reads[Seq[GitLabVersion]]])
 
-      def fileCommitsRequest(project: Project) =
+      def fileCommitsRequest(project: Project): Future[Response[List[FileCommit]]] =
         mockHttpClient.get[List[FileCommit]](
-          url = MockitoMatchers.eq(
-            s"${gitLabConfig.url}projects/${project.repository.get.value}/repository/files/${urlEncoder}"
-          ),
-          params = MockitoMatchers.any[Map[String, String]],
-          headers = MockitoMatchers.eq(gitLabConfig.token)
-        )(ec = MockitoMatchers.any[ExecutionContext], f = MockitoMatchers.any[Reads[List[FileCommit]]])
+          url = exact(s"${gitLabConfig.url}projects/${project.repositoryId.value}/repository/files/$urlEncoder"),
+          params = any[Map[String, String]],
+          headers = exact(gitLabConfig.token)
+        )(ec = any[ExecutionContext], f = any[Reads[List[FileCommit]]])
 
       "return list of Project versions with 200 response" taggedAs Service in {
-        when(projectVersionRequest(withRepoProject)).thenReturn(
-          Future.successful(
+        when(projectVersionRequest(projectWithRepo)).thenReturn {
+          Future.successful {
             Response[Seq[GitLabVersion]](HttpStatusCodes.OK, SuccessResponseBody(Seq(dummyVersionsJson)), Map())
-          )
-        )
-        when(fileCommitsRequest(withRepoProject)).thenReturn(
+          }
+        }
+        when(fileCommitsRequest(projectWithRepo)).thenReturn {
           Future.successful(Response[List[FileCommit]](HttpStatusCodes.OK, SuccessResponseBody(dummyCommitJson), Map()))
-        )
-        gitLabProjectVersioning.getFileVersions(withRepoProject, path).map {
+        }
+        gitLabProjectVersioning.getFileVersions(projectWithRepo, path).map {
           _ shouldBe Right(Seq(dummyGitLabVersion))
         }
       }
 
       "throw new VersioningException" taggedAs Service in {
         val errorText = ""
-        when(projectVersionRequest(withRepoProject)).thenReturn(
-          Future.successful(
+        when(projectVersionRequest(projectWithRepo)).thenReturn {
+          Future.successful {
             Response[Seq[GitLabVersion]](HttpStatusCodes.BadRequest, FailureResponseBody(errorText), Map())
-          )
-        )
-        when(fileCommitsRequest(withRepoProject)).thenReturn(
-          Future.successful(
+          }
+        }
+        when(fileCommitsRequest(projectWithRepo)).thenReturn {
+          Future.successful {
             Response[List[FileCommit]](HttpStatusCodes.BadRequest, FailureResponseBody("Response status: 400"), Map())
-          )
-        )
-        gitLabProjectVersioning.getFileCommits(withRepoProject, path).map {
-          _ shouldBe Left(
+          }
+        }
+        gitLabProjectVersioning.getFileCommits(projectWithRepo, path).map {
+          _ shouldBe Left {
             VersioningException.FileException("Could not take the file commits. ResponseBody: Response status: 400")
-          )
+          }
         }
       }
     }
@@ -417,82 +405,79 @@ class GitLabProjectVersioningTest
       val dummyFilesTree: List[FileTree] = List(dummyFileTree)
       val emptyListValidateResponse = "List((,List(JsonValidationError(List(error.expected.jsarray),WrappedArray())))"
       val version = dummyPipelineVersion
-      def request(project: Project, version: Option[PipelineVersion]) = {
+      def request(project: Project, version: Option[PipelineVersion]): Future[Response[List[FileTree]]] = {
         val versionId: Map[String, String] = version match {
           case Some(version) => Map("ref" -> version.name, "recursive" -> "true")
           case None          => Map()
         }
         mockHttpClient.get[List[FileTree]](
-          url = MockitoMatchers.eq(s"${gitLabConfig.url}projects/${project.repository.get.value}/repository/tree"),
-          params = MockitoMatchers.eq(versionId),
-          headers = MockitoMatchers.eq(gitLabConfig.token)
-        )(ec = MockitoMatchers.any[ExecutionContext], f = MockitoMatchers.any[Reads[List[FileTree]]])
+          url = exact(s"${gitLabConfig.url}projects/${project.repositoryId.value}/repository/tree"),
+          params = exact(versionId),
+          headers = exact(gitLabConfig.token)
+        )(ec = any[ExecutionContext], f = any[Reads[List[FileTree]]])
       }
 
       "return files tree without version with 200 response" taggedAs Service in {
-        when(request(withRepoProject, Option(null))).thenReturn(
+        when(request(projectWithRepo, None)).thenReturn {
           Future.successful(Response[List[FileTree]](HttpStatusCodes.OK, SuccessResponseBody(dummyFilesTree), Map()))
-        )
-        gitLabProjectVersioning.getFilesTree(withRepoProject, Option(null)).map(_ shouldBe Right(Seq(dummyFileTree)))
+        }
+        gitLabProjectVersioning.getFilesTree(projectWithRepo, None).map(_ shouldBe Right(Seq(dummyFileTree)))
       }
 
       "return files tree with version with 200 response" taggedAs Service in {
-        when(request(withRepoProject, Some(version))).thenReturn(
+        when(request(projectWithRepo, Some(version))).thenReturn {
           Future.successful(Response[List[FileTree]](HttpStatusCodes.OK, SuccessResponseBody(dummyFilesTree), Map()))
-        )
-        gitLabProjectVersioning.getFilesTree(withRepoProject, Some(version)).map(_ shouldBe Right(Seq(dummyFileTree)))
+        }
+        gitLabProjectVersioning.getFilesTree(projectWithRepo, Some(version)).map(_ shouldBe Right(Seq(dummyFileTree)))
       }
 
       "return files tree when there is not version" taggedAs Service in {
-        when(request(withRepoProject, Some(version))).thenReturn(
-          Future.successful(
+        when(request(projectWithRepo, Some(version))).thenReturn {
+          Future.successful {
             Response[List[FileTree]](HttpStatusCodes.OK, FailureResponseBody(emptyListValidateResponse), Map())
-          )
-        )
-        gitLabProjectVersioning
-          .getFilesTree(withRepoProject, Some(version))
-          .map(
-            _ shouldBe Left(
-              VersioningException.FileException(
-                s"Could not take the files tree or parse json. Response status: 200. ResponseBody: ${emptyListValidateResponse}"
-              )
-            )
-          )
+          }
+        }
+        gitLabProjectVersioning.getFilesTree(projectWithRepo, Some(version)).map {
+          _ shouldBe Left {
+            VersioningException.FileException {
+              s"Could not take the files tree or parse json. Response status: 200. ResponseBody: $emptyListValidateResponse"
+            }
+          }
+        }
       }
 
       "throw new VersioningException with 400 response" taggedAs Service in {
-        when(request(withRepoProject, Some(version))).thenReturn(
-          Future.successful(
+        when(request(projectWithRepo, Some(version))).thenReturn {
+          Future.successful {
             Response[List[FileTree]](
               HttpStatusCodes.BadRequest,
               FailureResponseBody(""),
               Map()
             )
-          )
-        )
-        gitLabProjectVersioning
-          .getFilesTree(withRepoProject, Some(version))
-          .map(
-            _ shouldBe Left(
-              VersioningException
-                .FileException("Could not take the files tree or parse json. Response status: 400. ResponseBody: ")
-            )
-          )
+          }
+        }
+        gitLabProjectVersioning.getFilesTree(projectWithRepo, Some(version)).map {
+          _ shouldBe Left {
+            VersioningException
+              .FileException("Could not take the files tree or parse json. Response status: 400. ResponseBody: ")
+          }
+        }
       }
     }
   }
 
   object ProjectContext {
     val EmptyHeaders: Map[String, Seq[String]] = Map()
-    lazy val activeProject: Project = TestProjectUtils.getDummyProject()
-    lazy val postProject: PostProject = PostProject(name = activeProject.name)
-    lazy val repositoryId: RepositoryId = TestProjectUtils.getDummyRepositoryId()
+    lazy val gitLabRepositoryResponse: GitLabRepositoryResponse = TestProjectUtils.getDummyGitLabRepositoryResponse()
+
+    lazy val activeLocalProject: LocalProject = TestProjectUtils.getDummyLocalProject().copy(active = true)
+    lazy val inactiveLocalProject: LocalProject = TestProjectUtils.getDummyLocalProject(active = false)
+    lazy val activeProject: Project = activeLocalProject.toProject(gitLabRepositoryResponse.id)
     lazy val inactiveProject: Project = activeProject.copy(active = false)
-    lazy val noRepoProject: Project = activeProject.copy(repository = None)
-    lazy val withRepoProject: Project =
-      activeProject.withRepository(Some(s"${gitLabConfig.idPath}${activeProject.projectId.value}"))
-    lazy val withGitlabProject: Project =
-      activeProject.withRepository(Some(s"${gitLabConfig.idPath}${repositoryId.id}"))
+    lazy val projectWithRepo: Project = activeLocalProject.toProject(gitLabRepositoryResponse.id)
+
+    lazy val postProject: PostProject = PostProject(name = activeProject.name)
+
     lazy val dummyPipelineVersion: PipelineVersion = TestProjectUtils.getDummyPipeLineVersion()
     lazy val dummyPipelineVersionHigher: PipelineVersion = dummyPipelineVersion.increaseMinor
     lazy val dummyGitLabVersion: GitLabVersion = TestProjectUtils.getDummyGitLabVersion()
@@ -504,7 +489,7 @@ class GitLabProjectVersioningTest
   }
 
   object ProjectFileContext {
-    val projectFileContent = ProjectFileContent("Hello world")
+    private val projectFileContent = ProjectFileContent("Hello world")
     val newFile: ProjectFile = ProjectFile(Paths.get("new_file.txt"), projectFileContent)
     val existFile: ProjectFile = ProjectFile(Paths.get("exist_file.txt"), projectFileContent)
   }

--- a/services/src/test/scala/cromwell/pipeline/service/ProjectServiceTest.scala
+++ b/services/src/test/scala/cromwell/pipeline/service/ProjectServiceTest.scala
@@ -2,7 +2,7 @@ package cromwell.pipeline.service
 
 import cromwell.pipeline.datastorage.dao.repository.ProjectRepository
 import cromwell.pipeline.datastorage.dao.repository.utils.TestProjectUtils
-import cromwell.pipeline.datastorage.dto.{ Project, ProjectAdditionRequest, ProjectId }
+import cromwell.pipeline.datastorage.dto.{ LocalProject, Project, ProjectAdditionRequest, ProjectId }
 import cromwell.pipeline.model.wrapper.UserId
 import cromwell.pipeline.service.Exceptions.ProjectNotFoundException
 import org.mockito.Matchers.any
@@ -27,7 +27,7 @@ class ProjectServiceTest extends AsyncWordSpec with Matchers with MockitoSugar w
         val projectId = dummyProject.projectId
         val ownerId = dummyProject.ownerId
 
-        when(projectVersioning.createRepository(any[Project])(any[ExecutionContext]))
+        when(projectVersioning.createRepository(any[LocalProject])(any[ExecutionContext]))
           .thenReturn(Future.successful(Right(dummyProject)))
         when(projectRepository.addProject(any[Project])).thenReturn(Future.successful(projectId))
 

--- a/utils/src/main/scala/cromwell/pipeline/utils/ApplicationConfig.scala
+++ b/utils/src/main/scala/cromwell/pipeline/utils/ApplicationConfig.scala
@@ -10,7 +10,6 @@ final case class WebServiceConfig(interface: String, port: Int) extends ConfigCo
 
 final case class GitLabConfig(
   url: String,
-  idPath: String,
   token: Map[String, String],
   defaultFileVersion: String,
   defaultBranch: String
@@ -70,7 +69,6 @@ class ApplicationConfig(val config: Config) {
     val _config = config.getConfig("database.gitlab")
     GitLabConfig(
       url = _config.getString("url"),
-      idPath = _config.getString("path") + "%2F",
       token = Map("PRIVATE-TOKEN" -> _config.getString("token")),
       defaultFileVersion = _config.getString("defaultFileVersion"),
       defaultBranch = _config.getString("defaultBranch")

--- a/utils/src/main/scala/cromwell/pipeline/utils/URLEncoderUtils.scala
+++ b/utils/src/main/scala/cromwell/pipeline/utils/URLEncoderUtils.scala
@@ -1,0 +1,12 @@
+package cromwell.pipeline.utils
+
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+object URLEncoderUtils {
+
+  private val encoding = StandardCharsets.UTF_8.toString
+
+  def encode(url: String): String = URLEncoder.encode(url, encoding)
+
+}


### PR DESCRIPTION
Explicitly store GitLab ID as `repositoryId`
Forbid to change `repositoryId`
Add RunController routes to all routes
Make `repositoryId` required field in `Project`