### PR TITLE
EPMLSTRCMW-208-Fix-File-Upload

### DIFF
--- a/controllers/src/main/scala/cromwell/pipeline/controller/ProjectFileController.scala
+++ b/controllers/src/main/scala/cromwell/pipeline/controller/ProjectFileController.scala
@@ -7,8 +7,9 @@ import cromwell.pipeline.datastorage.dto.auth.AccessTokenContent
 import cromwell.pipeline.datastorage.dto.{
   ProjectBuildConfigurationRequest,
   ProjectUpdateFileRequest,
-  ValidateFileContentRequest,
-  SuccessResponseMessage
+  SuccessResponseMessage,
+  UpdateFiledResponse,
+  ValidateFileContentRequest
 }
 import cromwell.pipeline.service.ProjectFileService
 import cromwell.pipeline.service.VersioningException._
@@ -53,7 +54,7 @@ class ProjectFileController(wdlService: ProjectFileService)(implicit val executi
                     }
                 }
               }) {
-                case Success((status, p @ SuccessResponseMessage(_))) =>
+                case Success((status, p @ UpdateFiledResponse(_, _))) =>
                   complete((status, p))
                 case Success((status, message)) => complete((status, s"File have not uploaded due to $message"))
                 case Failure(e)                 => complete(StatusCodes.InternalServerError, e.getMessage)

--- a/controllers/src/test/scala/cromwell/pipeline/controller/ProjectFileControllerTest.scala
+++ b/controllers/src/test/scala/cromwell/pipeline/controller/ProjectFileControllerTest.scala
@@ -56,7 +56,7 @@ class ProjectFileControllerTest extends AsyncWordSpec with Matchers with Scalate
       "return OK response for valid request with a valid file" taggedAs Controller in {
         when(projectFileService.validateFile(projectFileContent)).thenReturn(Future.successful(Right(())))
         when(projectFileService.uploadFile(project, projectFile, Some(version)))
-          .thenReturn(Future.successful(Right(SuccessResponseMessage("Success"))))
+          .thenReturn(Future.successful(Right(UpdateFiledResponse("test.wdl", "master"))))
         Post("/files", request) ~> projectFileController.route(accessToken) ~> check {
           status shouldBe StatusCodes.OK
         }
@@ -66,7 +66,7 @@ class ProjectFileControllerTest extends AsyncWordSpec with Matchers with Scalate
         when(projectFileService.validateFile(projectFileContent))
           .thenReturn(Future.successful(Left(ValidationError(List("Miss close bracket")))))
         when(projectFileService.uploadFile(project, projectFile, Some(version)))
-          .thenReturn(Future.successful(Right(SuccessResponseMessage("Success"))))
+          .thenReturn(Future.successful(Right(UpdateFiledResponse("test.wdl", "master"))))
         Post("/files", request) ~> projectFileController.route(accessToken) ~> check {
           status shouldBe StatusCodes.Created
         }

--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/Project.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/Project.scala
@@ -1,11 +1,11 @@
 package cromwell.pipeline.datastorage.dto
 
 import java.nio.file.{ Path, Paths }
-
 import cats.data.Validated
 import cats.implicits._
 import cromwell.pipeline.model.wrapper.{ UserId, VersionValue }
 import play.api.libs.functional.syntax._
+import play.api.libs.json.JsonNaming.SnakeCase
 import play.api.libs.json._
 import slick.lifted.MappedTo
 
@@ -234,6 +234,20 @@ final case class SuccessResponseMessage(message: String) extends AnyVal
 object SuccessResponseMessage {
   implicit lazy val successResponseMessageFormat: OFormat[SuccessResponseMessage] =
     Json.format[SuccessResponseMessage] // todo Json.valueFormat ?
+}
+
+/**
+ * Wrapper type contains success response message
+ *
+ * @param filePath where the file was stored
+ * @param branch where the file was stored
+ */
+final case class UpdateFiledResponse(filePath: String, branch: String)
+
+object UpdateFiledResponse {
+  implicit val config = JsonConfiguration(SnakeCase)
+  implicit lazy val updateFiledResponseFormat: OFormat[UpdateFiledResponse] =
+    Json.format[UpdateFiledResponse]
 }
 
 /**

--- a/services/src/main/scala/cromwell/pipeline/service/ProjectFileService.scala
+++ b/services/src/main/scala/cromwell/pipeline/service/ProjectFileService.scala
@@ -19,7 +19,7 @@ class ProjectFileService(womTool: WomToolAPI, projectVersioning: ProjectVersioni
     project: Project,
     projectFile: ProjectFile,
     version: Option[PipelineVersion]
-  ): Future[Either[VersioningException, SuccessResponseMessage]] =
+  ): Future[Either[VersioningException, UpdateFiledResponse]] =
     projectVersioning.updateFile(project, projectFile, version)
 
   def buildConfiguration(

--- a/services/src/main/scala/cromwell/pipeline/service/ProjectVersioning.scala
+++ b/services/src/main/scala/cromwell/pipeline/service/ProjectVersioning.scala
@@ -12,7 +12,7 @@ trait ProjectVersioning[E >: VersioningException] {
 
   def updateFile(project: Project, projectFile: ProjectFile, version: Option[PipelineVersion] = None)(
     implicit ec: ExecutionContext
-  ): AsyncResult[SuccessResponseMessage]
+  ): AsyncResult[UpdateFiledResponse]
 
   def updateFiles(project: Project, projectFiles: ProjectFiles)(
     implicit ec: ExecutionContext

--- a/services/src/test/scala/cromwell/pipeline/service/GitLabProjectVersioningTest.scala
+++ b/services/src/test/scala/cromwell/pipeline/service/GitLabProjectVersioningTest.scala
@@ -181,14 +181,14 @@ class GitLabProjectVersioningTest
           }
         }
         when {
-          mockHttpClient.put[SuccessResponseMessage, UpdateFileRequest](
+          mockHttpClient.put[UpdateFiledResponse, UpdateFileRequest](
             url = url,
             headers = gitLabConfig.token,
             payload = payload
           )
         }.thenReturn {
           Future.successful {
-            Response[SuccessResponseMessage](
+            Response[UpdateFiledResponse](
               StatusCodes.BadRequest.intValue,
               FailureResponseBody("File does not exist"),
               EmptyHeaders
@@ -196,16 +196,16 @@ class GitLabProjectVersioningTest
           }
         }
         when {
-          mockHttpClient.post[SuccessResponseMessage, UpdateFileRequest](
+          mockHttpClient.post[UpdateFiledResponse, UpdateFileRequest](
             url = url,
             headers = gitLabConfig.token,
             payload = payload
           )
         }.thenReturn {
           Future.successful(
-            Response[SuccessResponseMessage](
+            Response[UpdateFiledResponse](
               StatusCodes.OK.intValue,
-              SuccessResponseBody(SuccessResponseMessage(successCreateMessage)),
+              SuccessResponseBody(UpdateFiledResponse(newFile.path.toString, "master")),
               EmptyHeaders
             )
           )
@@ -228,7 +228,7 @@ class GitLabProjectVersioningTest
         }
 
         gitLabProjectVersioning.updateFile(projectWithRepo, newFile, Some(dummyPipelineVersionHigher)).map {
-          _ shouldBe Right(SuccessResponseMessage(successCreateMessage))
+          _ shouldBe Right(UpdateFiledResponse(newFile.path.toString, "master"))
         }
       }
 
@@ -248,22 +248,22 @@ class GitLabProjectVersioningTest
           }
         }
         when {
-          mockHttpClient.put[SuccessResponseMessage, UpdateFileRequest](
+          mockHttpClient.put[UpdateFiledResponse, UpdateFileRequest](
             url = url,
             headers = gitLabConfig.token,
             payload = payload
           )
         }.thenReturn {
           Future.successful {
-            Response[SuccessResponseMessage](
+            Response[UpdateFiledResponse](
               StatusCodes.OK.intValue,
-              SuccessResponseBody(SuccessResponseMessage(successUpdateMessage)),
+              SuccessResponseBody(UpdateFiledResponse(newFile.path.toString, "master")),
               EmptyHeaders
             )
           }
         }
         gitLabProjectVersioning.updateFile(projectWithRepo, existFile, Some(dummyPipelineVersionHigher)).map {
-          _ shouldBe Right(SuccessResponseMessage(successUpdateMessage))
+          _ shouldBe Right(UpdateFiledResponse(newFile.path.toString, "master"))
         }
       }
     }

--- a/services/src/test/scala/cromwell/pipeline/service/ProjectFileServiceTest.scala
+++ b/services/src/test/scala/cromwell/pipeline/service/ProjectFileServiceTest.scala
@@ -1,10 +1,15 @@
 package cromwell.pipeline.service
 
 import java.nio.file.Paths
-
 import cats.data.NonEmptyList
 import cromwell.pipeline.datastorage.dao.repository.utils.TestProjectUtils
-import cromwell.pipeline.datastorage.dto.{ ProjectFile, ProjectFileContent, SuccessResponseMessage, ValidationError }
+import cromwell.pipeline.datastorage.dto.{
+  ProjectFile,
+  ProjectFileContent,
+  SuccessResponseMessage,
+  UpdateFiledResponse,
+  ValidationError
+}
 import cromwell.pipeline.womtool.WomTool
 import org.mockito.Mockito.when
 import org.scalatest.{ AsyncWordSpec, Matchers }
@@ -47,10 +52,10 @@ class ProjectFileServiceTest extends AsyncWordSpec with Matchers with MockitoSug
 
       "return success message for request" taggedAs Service in {
         when(projectVersioning.updateFile(project, projectFile, Some(version)))
-          .thenReturn(Future.successful(Right(SuccessResponseMessage("Success"))))
+          .thenReturn(Future.successful(Right(UpdateFiledResponse(projectFile.path.toString, "master"))))
         projectFileService
           .uploadFile(project, projectFile, Some(version))
-          .map(_ shouldBe Right(SuccessResponseMessage("Success")))
+          .map(_ shouldBe Right(UpdateFiledResponse(projectFile.path.toString, "master")))
       }
 
       "return error message for error request" taggedAs Service in {


### PR DESCRIPTION
Implemented a new response to upload files to gitlab
instead of the SuccessResponseMessage. The git api is
returning a json response with the file_path and branch