### PR TITLE
[Suspended] feat: EPMLSTRCMW-182 Separately filter unsuccessful auth

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -105,7 +105,9 @@ lazy val repositories =
 
 lazy val services =
   (project in file("services"))
-    .settings(libraryDependencies ++= jsonDependencies ++ mongoDependencies ++ cromwellDependencies :+ cats :+ playJson)
+    .settings(
+      libraryDependencies ++= jsonDependencies ++ mongoDependencies ++ cromwellDependencies :+ cats :+ playJson :+ sl4j
+    )
     .dependsOn(
       repositories % "compile->compile;test->test",
       utils % "compile->compile;test->test",

--- a/controllers/src/main/scala/cromwell/pipeline/controller/AuthController.scala
+++ b/controllers/src/main/scala/cromwell/pipeline/controller/AuthController.scala
@@ -9,7 +9,8 @@ import cromwell.pipeline.service.AuthService
 import cromwell.pipeline.service.AuthorizationException.{
   DuplicateUserException,
   InactiveUserException,
-  IncorrectPasswordException
+  IncorrectPasswordException,
+  UserNotFoundException
 }
 import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
 
@@ -31,7 +32,9 @@ class AuthController(authService: AuthService)(implicit executionContext: Execut
                 case Failure(IncorrectPasswordException(message)) =>
                   complete(HttpResponse(StatusCodes.Unauthorized, entity = message))
                 case Failure(InactiveUserException(message)) =>
-                  complete(HttpResponse(StatusCodes.Forbidden, entity = message))
+                  complete(HttpResponse(StatusCodes.Unauthorized, entity = message))
+                case Failure(UserNotFoundException(message)) =>
+                  complete(HttpResponse(StatusCodes.Unauthorized, entity = message))
                 case _ => complete(StatusCodes.Unauthorized)
               }
           }

--- a/controllers/src/test/scala/cromwell/pipeline/controller/UserControllerTest.scala
+++ b/controllers/src/test/scala/cromwell/pipeline/controller/UserControllerTest.scala
@@ -119,7 +119,7 @@ class UserControllerTest
         val dummyUser: User = TestUserUtils.getDummyUser()
         val userId = UserId.random
         val accessToken = AccessTokenContent(userId)
-        val request = UserUpdateRequest(dummyUser.email, dummyUser.firstName, dummyUser.lastName)
+        val request = UserUpdateRequest(dummyUser.email.unwrap, dummyUser.firstName.unwrap, dummyUser.lastName.unwrap)
 
         when(userService.updateUser(userId, request)).thenReturn(Future.successful(1))
 
@@ -132,11 +132,7 @@ class UserControllerTest
         val dummyUser: User = TestUserUtils.getDummyUser()
         val userId = dummyUser.userId
         val accessToken = AccessTokenContent(userId)
-        val request = PasswordUpdateRequest(
-          Password(password, Enable.Unsafe),
-          Password(password, Enable.Unsafe),
-          Password(password, Enable.Unsafe)
-        )
+        val request = PasswordUpdateRequest(password, password, password)
 
         when(userService.updatePassword(userId, request)).thenReturn(Future.successful(1))
 
@@ -149,7 +145,7 @@ class UserControllerTest
         val dummyUser: User = TestUserUtils.getDummyUser()
         val userId = dummyUser.userId
         val accessToken = AccessTokenContent(userId)
-        val request = UserUpdateRequest(dummyUser.email, dummyUser.firstName, dummyUser.lastName)
+        val request = UserUpdateRequest(dummyUser.email.unwrap, dummyUser.firstName.unwrap, dummyUser.lastName.unwrap)
 
         when(userService.updateUser(userId, request))
           .thenReturn(Future.failed(new RuntimeException("Something wrong.")))
@@ -164,11 +160,7 @@ class UserControllerTest
         val userId = dummyUser.userId
         val accessToken = AccessTokenContent(userId)
         val request =
-          PasswordUpdateRequest(
-            Password(password, Enable.Unsafe),
-            Password(password + "1", Enable.Unsafe),
-            Password(password, Enable.Unsafe)
-          )
+          PasswordUpdateRequest(password, password, password)
 
         when(userService.updatePassword(userId, request))
           .thenReturn(Future.failed(new RuntimeException("Something wrong.")))

--- a/portal/src/it/scala/cromwell/pipeline/controller/AuthControllerItTest.scala
+++ b/portal/src/it/scala/cromwell/pipeline/controller/AuthControllerItTest.scala
@@ -8,13 +8,12 @@ import com.typesafe.config.Config
 import cromwell.pipeline.ApplicationComponents
 import cromwell.pipeline.controller.AuthController._
 import cromwell.pipeline.datastorage.dao.repository.utils.TestUserUtils
-import cromwell.pipeline.datastorage.dao.repository.utils.TestUserUtils._
 import cromwell.pipeline.datastorage.dto.User
-import cromwell.pipeline.service.AuthService
 import cromwell.pipeline.utils.TestContainersUtils
 import org.scalatest.compatible.Assertion
 import org.scalatest.concurrent.ScalaFutures._
-import org.scalatest.{ WordSpec, Matchers }
+import org.scalatest.{ Matchers, WordSpec }
+import TestUserUtils._
 
 class AuthControllerItTest extends WordSpec with Matchers with ScalatestRouteTest with ForAllTestContainer {
 
@@ -47,15 +46,15 @@ class AuthControllerItTest extends WordSpec with Matchers with ScalatestRouteTes
         }
       }
 
-      "return status Forbidden if user is inactive" in {
+      "return status Unauthorized if user is inactive" in {
         val dummyUser: User = TestUserUtils.getDummyUser(active = false)
         whenReady(userRepository.addUser(dummyUser)) { _ =>
           val signInRequestStr =
             s"""{"email":"${dummyUser.email}","password":"${userPassword}"}"""
           val httpEntity = HttpEntity(`application/json`, signInRequestStr)
           Post("/auth/signIn", httpEntity) ~> authController.route ~> check {
-            status shouldBe StatusCodes.Forbidden
-            responseAs[String] shouldEqual "User is not active"
+            status shouldBe StatusCodes.Unauthorized
+            responseAs[String] shouldEqual "user is not active"
           }
         }
       }
@@ -69,7 +68,7 @@ class AuthControllerItTest extends WordSpec with Matchers with ScalatestRouteTes
           val httpEntity = HttpEntity(`application/json`, signInRequestStr)
           Post("/auth/signIn", httpEntity) ~> authController.route ~> check {
             status shouldBe StatusCodes.Unauthorized
-            responseAs[String] shouldEqual AuthService.authorizationFailure
+            responseAs[String] shouldEqual "incorrect password"
           }
         }
       }

--- a/portal/src/it/scala/cromwell/pipeline/controller/UserControllerItTest.scala
+++ b/portal/src/it/scala/cromwell/pipeline/controller/UserControllerItTest.scala
@@ -74,7 +74,7 @@ class UserControllerItTest
 
       "return status code NoContent if user was successfully updated" in {
         val dummyUser: User = TestUserUtils.getDummyUser()
-        val request = UserUpdateRequest(dummyUser.email, dummyUser.firstName, dummyUser.lastName)
+        val request = UserUpdateRequest(dummyUser.email.unwrap, dummyUser.firstName.unwrap, dummyUser.lastName.unwrap)
         userRepository.addUser(dummyUser).flatMap { _ =>
           userRepository.updateUser(dummyUser).map { _ =>
             val accessToken = AccessTokenContent(dummyUser.userId)
@@ -90,12 +90,7 @@ class UserControllerItTest
 
       "return status code NoContent if user's password was successfully updated" in {
         val dummyUser: User = TestUserUtils.getDummyUser()
-        val request =
-          PasswordUpdateRequest(
-            Password(password, Enable.Unsafe),
-            Password("new$Password1", Enable.Unsafe),
-            Password("new$Password1", Enable.Unsafe)
-          )
+        val request = PasswordUpdateRequest(password, "new$Password1", "new$Password1")
         userRepository.addUser(dummyUser).flatMap { _ =>
           userRepository.updatePassword(dummyUser).map { _ =>
             val accessToken = AccessTokenContent(dummyUser.userId)

--- a/portal/src/main/resources/logback.xml
+++ b/portal/src/main/resources/logback.xml
@@ -5,7 +5,22 @@
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>INFO</level>
             <onMatch>ACCEPT</onMatch>
-            <onMismatch>DENY</onMismatch>
+        </filter>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>WARN</level>
+            <onMatch>ACCEPT</onMatch>
+        </filter>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>TRACE</level>
+            <onMatch>DENY</onMatch>
+        </filter>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>DEBUG</level>
+            <onMatch>DENY</onMatch>
+        </filter>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>DENY</onMatch>
         </filter>
         <encoder>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>

--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/auth/SignInRequest.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/auth/SignInRequest.scala
@@ -1,9 +1,8 @@
 package cromwell.pipeline.datastorage.dto.auth
 
-import cromwell.pipeline.model.wrapper.{ Password, UserEmail }
 import play.api.libs.json.{ Json, OFormat }
 
-final case class SignInRequest(email: UserEmail, password: Password)
+final case class SignInRequest(email: String, password: String)
 
 object SignInRequest {
   implicit val signInRequestFormat: OFormat[SignInRequest] = Json.format[SignInRequest]

--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/auth/SignUpRequest.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/auth/SignUpRequest.scala
@@ -1,9 +1,8 @@
 package cromwell.pipeline.datastorage.dto.auth
 
-import cromwell.pipeline.model.wrapper.{ Name, Password, UserEmail }
 import play.api.libs.json.{ Json, OFormat }
 
-final case class SignUpRequest(email: UserEmail, password: Password, firstName: Name, lastName: Name)
+final case class SignUpRequest(email: String, password: String, firstName: String, lastName: String)
 
 object SignUpRequest {
   implicit val signUpRequestFormat: OFormat[SignUpRequest] = Json.format[SignUpRequest]

--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/user/PasswordUpdateRequest.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/user/PasswordUpdateRequest.scala
@@ -1,9 +1,8 @@
 package cromwell.pipeline.datastorage.dto.user
 
-import cromwell.pipeline.model.wrapper.Password
 import play.api.libs.json.{ Json, OFormat }
 
-final case class PasswordUpdateRequest(currentPassword: Password, newPassword: Password, repeatPassword: Password)
+final case class PasswordUpdateRequest(currentPassword: String, newPassword: String, repeatPassword: String)
 
 object PasswordUpdateRequest {
   implicit val updatePasswordRequestFormat: OFormat[PasswordUpdateRequest] = Json.format[PasswordUpdateRequest]

--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/user/UserUpdateRequest.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/user/UserUpdateRequest.scala
@@ -1,9 +1,8 @@
 package cromwell.pipeline.datastorage.dto.user
 
-import cromwell.pipeline.model.wrapper.{ Name, UserEmail }
 import play.api.libs.json.{ Json, OFormat }
 
-final case class UserUpdateRequest(email: UserEmail, firstName: Name, lastName: Name)
+final case class UserUpdateRequest(email: String, firstName: String, lastName: String)
 
 object UserUpdateRequest {
   implicit val updateRequestFormat: OFormat[UserUpdateRequest] = Json.format[UserUpdateRequest]

--- a/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/UserRepositoryTest.scala
+++ b/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/UserRepositoryTest.scala
@@ -22,7 +22,7 @@ class UserRepositoryTest extends AsyncWordSpec with Matchers with BeforeAndAfter
     datastorageModule.pipelineDatabaseEngine.updateSchema()
   }
 
-  private val newPasswordHash: String = StringUtils.calculatePasswordHash("newPassword_1", "salt")
+  private val newPasswordHash: String = StringUtils.calculatePasswordHash("newPassword1_", "salt")
 
   "UserRepository" when {
 

--- a/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/utils/GeneratorUtils.scala
+++ b/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/utils/GeneratorUtils.scala
@@ -73,24 +73,24 @@ object GeneratorUtils {
     email <- emailGen
     firstName <- nameGen
     lastName <- nameGen
-  } yield UserUpdateRequest(email, firstName, lastName)
+  } yield UserUpdateRequest(email.unwrap, firstName.unwrap, lastName.unwrap)
 
   lazy val passwordUpdateRequestGen: Gen[PasswordUpdateRequest] = for {
     currentPassword <- passwordGen
     newPassword <- passwordGen
-  } yield PasswordUpdateRequest(currentPassword, newPassword, newPassword)
+  } yield PasswordUpdateRequest(currentPassword.value, newPassword.value, newPassword.value)
 
   lazy val signUpRequestGen: Gen[SignUpRequest] = for {
     email <- emailGen
     password <- passwordGen
     firstName <- nameGen
     lastName <- nameGen
-  } yield SignUpRequest(email, password, firstName, lastName)
+  } yield SignUpRequest(email.unwrap, password.value, firstName.unwrap, lastName.unwrap)
 
   lazy val signInRequestGen: Gen[SignInRequest] = for {
     email <- emailGen
     password <- passwordGen
-  } yield SignInRequest(email, password)
+  } yield SignInRequest(email.unwrap, password.value)
 
   lazy val projectAdditionRequestGen: Gen[ProjectAdditionRequest] = stringGen().map(ProjectAdditionRequest(_))
 

--- a/services/src/main/scala/cromwell/pipeline/service/AuthService.scala
+++ b/services/src/main/scala/cromwell/pipeline/service/AuthService.scala
@@ -1,8 +1,9 @@
 package cromwell.pipeline.service
 
-import java.time.Instant
+import cats.Show
 
-import cats.data.OptionT
+import java.time.Instant
+import cats.data.{ NonEmptyChain, Validated }
 import cats.implicits._
 import cromwell.pipeline.auth.AuthUtils
 import cromwell.pipeline.datastorage.dao.repository.UserRepository
@@ -15,39 +16,93 @@ import cromwell.pipeline.datastorage.dto.auth.{
   SignInRequest,
   SignUpRequest
 }
-import cromwell.pipeline.model.wrapper.UserId
-import cromwell.pipeline.service.AuthService.{ authorizationFailure, inactiveUserMessage }
+import cromwell.pipeline.model.wrapper.{ Name, Password, UserEmail, UserId }
+import cromwell.pipeline.service.AuthService.{
+  existUserMessage,
+  inactiveUserMessage,
+  incorrectPasswordMessage,
+  invalidEmailMessage,
+  invalidNameMessage,
+  invalidPasswordMessage,
+  userNotFoundMessage
+}
 import cromwell.pipeline.service.AuthorizationException.{
+  AuthorizationFailureException,
   DuplicateUserException,
   InactiveUserException,
-  IncorrectPasswordException
+  IncorrectPasswordException,
+  RegistrationFailureException,
+  UserNotFoundException
 }
 import cromwell.pipeline.utils.StringUtils
 import play.api.libs.json.Json
 
 import scala.concurrent.{ ExecutionContext, Future }
+import org.slf4j.{ Logger, LoggerFactory }
+
 import scala.util.Random
 
 class AuthService(userRepository: UserRepository, authUtils: AuthUtils)(implicit executionContext: ExecutionContext) {
 
   import authUtils._
+  val log: Logger = LoggerFactory.getLogger(getClass)
 
-  def signIn(request: SignInRequest): Future[Option[AuthResponse]] =
-    takeUserFromRequest(request).subflatMap(responseFromUser).value
+  def signIn(request: SignInRequest): Future[Option[AuthResponse]] = {
 
-  def signUp(request: SignUpRequest): Future[Option[AuthResponse]] =
-    userRepository.getUserByEmail(request.email).flatMap {
-      case Some(_) => Future.failed(DuplicateUserException(s"${request.email} already exists"))
+    def failMsg(cause: String): String = s"Authorization failure with email ${request.email} : $cause"
+
+    val data: Either[NonEmptyChain[String], Future[Option[AuthResponse]]] = for {
+      email <- logged(
+        UserEmail.from(request.email),
+        failMsg(invalidEmailMessage)
+      ).toEither
+      password <- logged(
+        Password.from(request.password),
+        failMsg(invalidPasswordMessage)
+      ).toEither
+    } yield takeUserFromRequest(email, password).map(responseFromUser)
+
+    data match {
+      case Right(value) => value
+      case Left(error)  => Future.failed(AuthorizationFailureException(error.show))
+    }
+  }
+
+  def signUp(request: SignUpRequest): Future[Option[AuthResponse]] = {
+
+    def failMsg(cause: String): String = s"Registration failure with email ${request.email} : $cause"
+
+    val data: Either[NonEmptyChain[String], Future[Option[AuthResponse]]] = for {
+      email <- logged(
+        UserEmail.from(request.email),
+        failMsg(invalidEmailMessage)
+      ).toEither
+      firstname <- logged(
+        Name.from(request.firstName),
+        failMsg(s"$invalidNameMessage [${request.firstName}]")
+      ).toEither
+      lastname <- logged(
+        Name.from(request.lastName),
+        failMsg(s"$invalidNameMessage [${request.lastName}]")
+      ).toEither
+      password <- logged(
+        Password.from(request.password),
+        failMsg(invalidPasswordMessage)
+      ).toEither
+    } yield userRepository.getUserByEmail(email).flatMap {
+      case Some(_) =>
+        log.warn(failMsg(existUserMessage))
+        Future.failed(DuplicateUserException(s"$email $existUserMessage"))
       case None =>
         val passwordSalt = Random.nextLong().toHexString
-        val passwordHash = StringUtils.calculatePasswordHash(request.password.value, passwordSalt)
+        val passwordHash = StringUtils.calculatePasswordHash(password.value, passwordSalt)
         val newUser = User(
           userId = UserId.random,
-          email = request.email,
+          email = email,
           passwordSalt = passwordSalt,
           passwordHash = passwordHash,
-          firstName = request.firstName,
-          lastName = request.lastName
+          firstName = firstname,
+          lastName = lastname
         )
         userRepository.addUser(newUser).map { userId =>
           val accessTokenContent = AccessTokenContent(userId)
@@ -55,6 +110,12 @@ class AuthService(userRepository: UserRepository, authUtils: AuthUtils)(implicit
           getAuthResponse(accessTokenContent, refreshTokenContent, Instant.now.getEpochSecond)
         }
     }
+
+    data match {
+      case Right(value) => value
+      case Left(error)  => Future.failed(RegistrationFailureException(error.show))
+    }
+  }
 
   // Info: Do not move the logic of creating new access token content to another place,
   //       otherwise authentication testing will become a challenging task.
@@ -72,14 +133,23 @@ class AuthService(userRepository: UserRepository, authUtils: AuthUtils)(implicit
       .flatten
   }
 
-  def takeUserFromRequest(request: SignInRequest): OptionT[Future, User] =
-    OptionT(userRepository.getUserByEmail(request.email)).semiflatMap[User] { user =>
-      val checkFilters = passwordCorrect(request, user).orElse(userIsActive(user))
-      checkFilters match {
-        case Some(value) => Future.failed(value)
-        case None        => Future.successful(user)
-      }
+  def takeUserFromRequest(email: UserEmail, password: Password): Future[User] = {
+
+    def failMsg(cause: String): String = s"Authorization failure with email $email : $cause"
+
+    userRepository.getUserByEmail(email).flatMap {
+      case Some(user) =>
+        passwordCorrect(password, user).orElse(userIsActive(user)) match {
+          case Some(value) =>
+            log.warn(failMsg(value.getMessage))
+            Future.failed(value)
+          case None => Future.successful(user)
+        }
+      case None =>
+        log.warn(failMsg(userNotFoundMessage))
+        Future.failed(UserNotFoundException(userNotFoundMessage))
     }
+  }
 
   def responseFromUser(user: User): Option[AuthResponse] = {
     val accessTokenContent = AccessTokenContent(user.userId)
@@ -87,17 +157,35 @@ class AuthService(userRepository: UserRepository, authUtils: AuthUtils)(implicit
     getAuthResponse(accessTokenContent, refreshTokenContent, Instant.now.getEpochSecond)
   }
 
-  def passwordCorrect(request: SignInRequest, user: User): Option[Throwable] =
-    if (user.passwordHash == StringUtils.calculatePasswordHash(request.password.value, user.passwordSalt)) None
-    else Some(IncorrectPasswordException(authorizationFailure))
+  def passwordCorrect(password: Password, user: User): Option[Throwable] =
+    if (user.passwordHash == StringUtils.calculatePasswordHash(password.value, user.passwordSalt)) {
+      None
+    } else {
+      Some(IncorrectPasswordException(incorrectPasswordMessage))
+    }
 
   def userIsActive(user: User): Option[Throwable] =
-    if (user.active) None else Some(InactiveUserException(inactiveUserMessage))
+    if (user.active) {
+      None
+    } else {
+      Some(InactiveUserException(inactiveUserMessage))
+    }
+
+  def logged[E: Show, A](validated: Validated[E, A], error: => String): Validated[E, A] =
+    validated.leftMap { e =>
+      log.warn(s"$error. Reason: [${e.show}]")
+      e
+    }
 }
 
 object AuthService {
-  val authorizationFailure = "invalid email or password"
-  val inactiveUserMessage = "User is not active"
+  val incorrectPasswordMessage = "incorrect password"
+  val inactiveUserMessage = "user is not active"
+  val invalidPasswordMessage = "invalid password"
+  val invalidEmailMessage = "invalid email"
+  val invalidNameMessage = "invalid name"
+  val userNotFoundMessage = "user has not been found"
+  val existUserMessage = "already exists"
 }
 
 sealed abstract class AuthorizationException extends Exception { val message: String }
@@ -106,5 +194,7 @@ object AuthorizationException {
   case class IncorrectPasswordException(message: String) extends AuthorizationException()
   case class DuplicateUserException(message: String) extends AuthorizationException()
   case class InactiveUserException(message: String) extends AuthorizationException()
-
+  case class UserNotFoundException(message: String) extends AuthorizationException()
+  case class AuthorizationFailureException(message: String) extends AuthorizationException()
+  case class RegistrationFailureException(message: String) extends AuthorizationException()
 }

--- a/services/src/main/scala/cromwell/pipeline/service/UserService.scala
+++ b/services/src/main/scala/cromwell/pipeline/service/UserService.scala
@@ -1,15 +1,31 @@
 package cromwell.pipeline.service
 
+import cats.Show
+import cats.data.{ NonEmptyChain, Validated }
+import cats.implicits._
 import cromwell.pipeline.datastorage.dao.repository.UserRepository
 import cromwell.pipeline.datastorage.dto.user.{ PasswordUpdateRequest, UserUpdateRequest }
 import cromwell.pipeline.datastorage.dto.{ User, UserNoCredentials }
-import cromwell.pipeline.model.wrapper.UserId
+import cromwell.pipeline.model.wrapper.{ Name, Password, UserEmail, UserId }
+import cromwell.pipeline.service.UserService.{
+  incorrectCurrentPassword,
+  incorrectDuplicatedMessage,
+  invalidCurrentPasswordMessage,
+  invalidEmailMessage,
+  invalidNameMessage,
+  invalidNewPasswordMessage,
+  invalidRepeatPasswordMessage,
+  userNotFoundMessage
+}
 import cromwell.pipeline.utils.StringUtils._
+import org.slf4j.{ Logger, LoggerFactory }
 
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.Random
 
 class UserService(userRepository: UserRepository)(implicit executionContext: ExecutionContext) {
+
+  val log: Logger = LoggerFactory.getLogger(getClass)
 
   def getUsersByEmail(emailPattern: String): Future[Seq[User]] =
     userRepository.getUsersByEmail(emailPattern)
@@ -20,33 +36,104 @@ class UserService(userRepository: UserRepository)(implicit executionContext: Exe
       user <- userRepository.getUserById(userId)
     } yield user.map(UserNoCredentials.fromUser)
 
-  def updateUser(userId: UserId, request: UserUpdateRequest): Future[Int] =
+  def updateUser(userId: UserId, request: UserUpdateRequest): Future[Int] = {
+
+    def failMsg(email: UserEmail, cause: String): String = s"User info updating failure with email $email : $cause"
+
     userRepository.getUserById(userId).flatMap {
       case Some(user) =>
-        userRepository.updateUser(
-          user.copy(email = request.email, firstName = request.firstName, lastName = request.lastName)
+        val data: Either[NonEmptyChain[String], Future[Int]] = for {
+          email <- logged(
+            UserEmail.from(request.email),
+            failMsg(user.email, invalidEmailMessage)
+          ).toEither
+          firstname <- logged(
+            Name.from(request.firstName),
+            failMsg(email, s"$invalidNameMessage [${request.firstName}]")
+          ).toEither
+          lastname <- logged(
+            Name.from(request.lastName),
+            failMsg(email, s"$invalidNameMessage [${request.lastName}]")
+          ).toEither
+        } yield userRepository.updateUser(
+          user.copy(email = email, firstName = firstname, lastName = lastname)
         )
-      case None => Future.failed(new RuntimeException("user with this id doesn't exist"))
+
+        data match {
+          case Right(value) => value
+          case Left(error)  => Future.failed(new RuntimeException(error.show))
+        }
+
+      case None =>
+        log.warn(s"$userNotFoundMessage $userId")
+        Future.failed(new RuntimeException(userNotFoundMessage))
     }
+  }
 
   def updatePassword(
     userId: UserId,
     request: PasswordUpdateRequest,
     salt: String = Random.nextLong().toHexString
-  ): Future[Int] =
-    if (request.newPassword == request.repeatPassword) {
-      userRepository.getUserById(userId).flatMap {
-        case Some(user) =>
-          user match {
-            case user
-                if user.passwordHash == calculatePasswordHash(request.currentPassword.unwrap, user.passwordSalt) => {
-              val passwordSalt = salt
-              val passwordHash = calculatePasswordHash(request.newPassword.unwrap, passwordSalt)
-              userRepository.updatePassword(user.copy(passwordSalt = passwordSalt, passwordHash = passwordHash))
+  ): Future[Int] = {
+
+    def failMsg(email: UserEmail, cause: String): String = s"Password updating failure with email $email : $cause"
+
+    userRepository.getUserById(userId).flatMap {
+      case Some(user) =>
+        val data: Either[NonEmptyChain[String], Future[Int]] = for {
+          currentPassword <- logged(
+            Password.from(request.currentPassword),
+            failMsg(user.email, invalidCurrentPasswordMessage)
+          ).toEither
+          newPassword <- logged(
+            Password.from(request.newPassword),
+            failMsg(user.email, invalidNewPasswordMessage)
+          ).toEither
+          repeatPassword <- logged(
+            Password.from(request.repeatPassword),
+            failMsg(user.email, invalidRepeatPasswordMessage)
+          ).toEither
+        } yield
+          if (newPassword != repeatPassword) {
+            log.warn(failMsg(user.email, incorrectDuplicatedMessage))
+            Future.failed(new RuntimeException(incorrectDuplicatedMessage))
+          } else {
+            user match {
+              case user if user.passwordHash == calculatePasswordHash(currentPassword.value, user.passwordSalt) =>
+                val passwordSalt = salt
+                val passwordHash = calculatePasswordHash(newPassword.value, passwordSalt)
+                userRepository.updatePassword(user.copy(passwordSalt = passwordSalt, passwordHash = passwordHash))
+              case _ =>
+                log.warn(failMsg(user.email, incorrectCurrentPassword))
+                Future.failed(new RuntimeException(incorrectCurrentPassword))
             }
-            case _ => Future.failed(new RuntimeException("user password differs from entered"))
           }
-        case None => Future.failed(new RuntimeException("user with this id doesn't exist"))
-      }
-    } else Future.failed(new RuntimeException("new password incorrectly duplicated"))
+
+        data match {
+          case Right(value) => value
+          case Left(error)  => Future.failed(new RuntimeException(error.show))
+        }
+
+      case None =>
+        log.warn(s"$userNotFoundMessage $userId")
+        Future.failed(new RuntimeException(userNotFoundMessage))
+    }
+  }
+
+  def logged[E: Show, A](validated: Validated[E, A], error: => String): Validated[E, A] =
+    validated.leftMap { e =>
+      log.warn(s"$error. Reason: [${e.show}]")
+      e
+    }
+}
+
+object UserService {
+  val invalidCurrentPasswordMessage = "invalid current password"
+  val invalidNewPasswordMessage = "invalid new password"
+  val invalidRepeatPasswordMessage = "invalid repeat password"
+  val invalidEmailMessage = "invalid email"
+  val invalidNameMessage = "invalid name"
+  val userNotFoundMessage = "user has not been found"
+  val incorrectDuplicatedMessage = "new password incorrectly duplicated"
+  val incorrectCurrentPassword = "user password differs from entered"
 }


### PR DESCRIPTION
In order to get log messages in `userEmail : message` format I had to move object validation calls into services.

Earlier validations were called automatically while unmarshalling was running, it made getting log messages in the correct format impossible. 