### PR TITLE
EPMLSTRCMW-204 Feat: Allow different users to create projects with the same name

### DIFF
--- a/controllers/src/main/scala/cromwell/pipeline/controller/ProjectController.scala
+++ b/controllers/src/main/scala/cromwell/pipeline/controller/ProjectController.scala
@@ -51,11 +51,7 @@ class ProjectController(projectService: ProjectService) {
   private def updateProject(implicit accessToken: AccessTokenContent): Route = put {
     entity(as[ProjectUpdateNameRequest]) { request =>
       onComplete(projectService.updateProjectName(request, accessToken.userId)) {
-        case Success(result) =>
-          result match {
-            case Left(e)  => complete(StatusCodes.InternalServerError, e.getMessage)
-            case Right(_) => complete(StatusCodes.OK)
-          }
+        case Success(_) => complete(StatusCodes.OK)
         case Failure(e) => complete(StatusCodes.InternalServerError, e.getMessage)
       }
     }

--- a/controllers/src/test/scala/cromwell/pipeline/controller/ProjectControllerTest.scala
+++ b/controllers/src/test/scala/cromwell/pipeline/controller/ProjectControllerTest.scala
@@ -112,8 +112,7 @@ class ProjectControllerTest extends AsyncWordSpec with Matchers with ScalatestRo
         val dummyProject = TestProjectUtils.getDummyProject()
         val request = ProjectUpdateNameRequest(dummyProject.projectId, dummyProject.name)
 
-        when(projectService.updateProjectName(request, userId))
-          .thenReturn(Future.successful(Right(dummyProject.projectId)))
+        when(projectService.updateProjectName(request, userId)).thenReturn(Future.successful(dummyProject.projectId))
 
         Put("/projects", request) ~> projectController.route(accessToken) ~> check {
           status shouldBe StatusCodes.OK

--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/Project.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/Project.scala
@@ -48,13 +48,6 @@ object PostProject {
   implicit lazy val postProject: OFormat[PostProject] = Json.format[PostProject]
 }
 
-final case class UpdateProjectGitLabRequest(name: String)
-
-object UpdateProjectGitLabRequest {
-  implicit lazy val updateProjectGitLabRequestFormat: OFormat[UpdateProjectGitLabRequest] =
-    Json.format[UpdateProjectGitLabRequest]
-}
-
 final case class ProjectId(value: String) extends MappedTo[String]
 
 object ProjectId {

--- a/services/src/main/scala/cromwell/pipeline/service/GitLabProjectVersioning.scala
+++ b/services/src/main/scala/cromwell/pipeline/service/GitLabProjectVersioning.scala
@@ -110,7 +110,7 @@ class GitLabProjectVersioning(httpClient: HttpClient, config: GitLabConfig)
       Future.failed(VersioningException.RepositoryException("Could not create a repository for deleted project."))
     } else {
       val createRepoUrl: String = s"${config.url}projects"
-      val postProject = PostProject(name = localProject.name)
+      val postProject = PostProject(name = localProject.projectId.value)
       httpClient
         .post[GitLabRepositoryResponse, PostProject](url = createRepoUrl, headers = config.token, payload = postProject)
         .map {
@@ -120,31 +120,6 @@ class GitLabProjectVersioning(httpClient: HttpClient, config: GitLabConfig)
             Left {
               VersioningException.RepositoryException {
                 s"The repository was not created. Response status: $statusCode; Response body [$error]"
-              }
-            }
-        }
-        .recover { case e: Throwable => Left(VersioningException.HttpException(e.getMessage)) }
-    }
-
-  override def updateRepositoryName(project: Project)(implicit ec: ExecutionContext): AsyncResult[Project] =
-    if (!project.active) {
-      Future.failed(VersioningException.RepositoryException("Could not update a repository for deleted project."))
-    } else {
-      val editRepoUrl: String = s"${config.url}projects/${project.repositoryId.value}"
-      val updateProjectGitLabRequest = UpdateProjectGitLabRequest(name = project.name)
-      httpClient
-        .put[GitLabRepositoryResponse, UpdateProjectGitLabRequest](
-          url = editRepoUrl,
-          headers = config.token,
-          payload = updateProjectGitLabRequest
-        )
-        .map {
-          case Response(_, SuccessResponseBody(_), _) =>
-            Right(project)
-          case Response(statusCode, FailureResponseBody(error), _) =>
-            Left {
-              VersioningException.RepositoryException {
-                s"The repository was not updated. Response status: $statusCode; Response body [$error]"
               }
             }
         }

--- a/services/src/main/scala/cromwell/pipeline/service/ProjectService.scala
+++ b/services/src/main/scala/cromwell/pipeline/service/ProjectService.scala
@@ -50,17 +50,10 @@ class ProjectService(projectRepository: ProjectRepository, projectVersioning: Pr
       }
     }
 
-  def updateProjectName(
-    request: ProjectUpdateNameRequest,
-    userId: UserId
-  ): Future[Either[VersioningException, ProjectId]] =
+  def updateProjectName(request: ProjectUpdateNameRequest, userId: UserId): Future[ProjectId] =
     getUserProjectById(request.projectId, userId).flatMap { project =>
       val updatedProject = project.copy(name = request.name)
-      projectVersioning.updateRepositoryName(updatedProject).flatMap {
-        case Left(exception) => Future.successful(Left(exception))
-        case Right(_) =>
-          projectRepository.updateProjectName(updatedProject).map(_ => Right(updatedProject.projectId))
-      }
+      projectRepository.updateProjectName(updatedProject).map(_ => updatedProject.projectId)
     }
 
   def updateProjectVersion(projectId: ProjectId, version: PipelineVersion, userId: UserId): Future[Int] =

--- a/services/src/main/scala/cromwell/pipeline/service/ProjectVersioning.scala
+++ b/services/src/main/scala/cromwell/pipeline/service/ProjectVersioning.scala
@@ -22,10 +22,6 @@ trait ProjectVersioning[E >: VersioningException] {
     implicit ec: ExecutionContext
   ): AsyncResult[Project]
 
-  def updateRepositoryName(project: Project)(
-    implicit ec: ExecutionContext
-  ): AsyncResult[Project]
-
   def getFiles(project: Project, path: Path)(
     implicit ec: ExecutionContext
   ): AsyncResult[List[String]]

--- a/services/src/test/scala/cromwell/pipeline/service/GitLabProjectVersioningTest.scala
+++ b/services/src/test/scala/cromwell/pipeline/service/GitLabProjectVersioningTest.scala
@@ -138,59 +138,6 @@ class GitLabProjectVersioningTest extends AsyncWordSpec with Matchers with Mocki
       }
     }
 
-    "updateRepository" should {
-
-      def request(putProject: UpdateProjectGitLabRequest): Future[Response[GitLabRepositoryResponse]] =
-        mockHttpClient.put[GitLabRepositoryResponse, UpdateProjectGitLabRequest](
-          url = s"${gitLabConfig.url}projects/${updatingProject.repositoryId.value}",
-          headers = gitLabConfig.token,
-          payload = putProject
-        )
-
-      "fail with VersioningException for inactive project" taggedAs Service in {
-        gitLabProjectVersioning.updateRepositoryName(inactiveProject).failed.map {
-          _ shouldBe VersioningException.RepositoryException("Could not update a repository for deleted project.")
-        }
-      }
-
-      "return updated Project with 200 response" taggedAs Service in {
-
-        when(request(putUpdateProject)).thenReturn {
-          Future.successful {
-            Response[GitLabRepositoryResponse](
-              HttpStatusCodes.Created,
-              SuccessResponseBody[GitLabRepositoryResponse](gitLabRepositoryResponse),
-              EmptyHeaders
-            )
-          }
-        }
-
-        gitLabProjectVersioning.updateRepositoryName(updatingProject).map {
-          _ shouldBe Right(updatingProject)
-        }
-      }
-
-      "fail with VersioningException with 400 response" taggedAs Service in {
-        val errorMsg = "The repository was not updated. Response status: 400"
-        when(request(putUpdateProject)).thenReturn {
-          Future.successful {
-            Response[GitLabRepositoryResponse](
-              HttpStatusCodes.BadRequest,
-              FailureResponseBody(errorMsg),
-              EmptyHeaders
-            )
-          }
-        }
-        gitLabProjectVersioning.updateRepositoryName(updatingProject).map {
-          _ shouldBe Left {
-            VersioningException.RepositoryException {
-              s"The repository was not updated. Response status: 400; Response body [$errorMsg]"
-            }
-          }
-        }
-      }
-    }
-
     "getProjectVersions" should {
       def request(project: Project): Future[Response[Seq[GitLabVersion]]] =
         mockHttpClient.get[Seq[GitLabVersion]](
@@ -573,12 +520,10 @@ class GitLabProjectVersioningTest extends AsyncWordSpec with Matchers with Mocki
     lazy val activeLocalProject: LocalProject = TestProjectUtils.getDummyLocalProject().copy(active = true)
     lazy val inactiveLocalProject: LocalProject = TestProjectUtils.getDummyLocalProject(active = false)
     lazy val activeProject: Project = activeLocalProject.toProject(gitLabRepositoryResponse.id)
-    lazy val updatingProject: Project = activeProject.copy(name = "New" + activeProject.name)
     lazy val inactiveProject: Project = activeProject.copy(active = false)
     lazy val projectWithRepo: Project = activeLocalProject.toProject(gitLabRepositoryResponse.id)
 
-    lazy val postProject: PostProject = PostProject(name = activeProject.name)
-    lazy val putUpdateProject: UpdateProjectGitLabRequest = UpdateProjectGitLabRequest(name = updatingProject.name)
+    lazy val postProject: PostProject = PostProject(name = activeProject.projectId.value)
 
     lazy val dummyPipelineVersion: PipelineVersion = TestProjectUtils.getDummyPipeLineVersion()
     lazy val dummyPipelineVersionHigher: PipelineVersion = dummyPipelineVersion.increaseMinor

--- a/services/src/test/scala/cromwell/pipeline/service/ProjectServiceTest.scala
+++ b/services/src/test/scala/cromwell/pipeline/service/ProjectServiceTest.scala
@@ -53,12 +53,10 @@ class ProjectServiceTest extends AsyncWordSpec with Matchers with MockitoSugar {
         val request = ProjectUpdateNameRequest(projectId, name = newProjectName)
 
         when(projectRepository.getProjectById(projectId)).thenReturn(Future.successful(Some(dummyProject)))
-        when(projectVersioning.updateRepositoryName(any[Project])(any[ExecutionContext]))
-          .thenReturn(Future.successful(Right(dummyProject)))
         when(projectRepository.updateProjectName(dummyProject.copy(name = newProjectName)))
           .thenReturn(Future.successful(1))
 
-        projectService.updateProjectName(request, ownerId).map { _ shouldBe Right(projectId) }
+        projectService.updateProjectName(request, ownerId).map { _ shouldBe projectId }
       }
     }
 


### PR DESCRIPTION
feat: Allow different users to create projects with the same name

- Gitlab demands unique project names, so in createRepository method instead of projectName projectId is used 
- All other changes derived from deleting updateRepositoryName functionality