### PR TITLE
EPMLSTRCMW-249

### DIFF
--- a/portal/src/it/scala/cromwell/pipeline/controller/ProjectControllerItTest.scala
+++ b/portal/src/it/scala/cromwell/pipeline/controller/ProjectControllerItTest.scala
@@ -48,7 +48,7 @@ class ProjectControllerItTest
 
   "ProjectController" when {
     "getProjectByName" should {
-      "return a project with the same name" in {
+      "return a project with the same name and current userId" in {
         val projectByNameRequest = dummyProject.name
         val accessToken = AccessTokenContent(dummyProject.ownerId)
 
@@ -64,6 +64,16 @@ class ProjectControllerItTest
 
         Get("/projects?name=" + projectByNameRequest) ~> projectController.route(accessToken) ~> check {
           status shouldBe StatusCodes.Forbidden
+        }
+      }
+
+      "return a status code 404 if project doesn't exist" in {
+        val nonExistProject = TestProjectUtils.getDummyProject()
+        val projectByNameRequest = nonExistProject.name
+        val accessToken = AccessTokenContent(nonExistProject.ownerId)
+
+        Get("/projects?name=" + projectByNameRequest) ~> projectController.route(accessToken) ~> check {
+          status shouldBe StatusCodes.NotFound
         }
       }
     }

--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/dao/entry/ProjectEntry.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/dao/entry/ProjectEntry.scala
@@ -31,8 +31,8 @@ trait ProjectEntry { this: Profile with UserEntry with CustomsWithEnumSupport wi
     projects.filter(_.projectId === projectId).take(1)
   }
 
-  def getProjectByNameAction = Compiled { name: Rep[String] =>
-    projects.filter(_.name === name).take(1)
+  def getProjectsByNameAction = Compiled { name: Rep[String] =>
+    projects.filter(_.name === name)
   }
 
   def addProjectAction(project: Project): ActionResult[ProjectId] =

--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/dao/repository/ProjectRepository.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/dao/repository/ProjectRepository.scala
@@ -14,8 +14,8 @@ class ProjectRepository(pipelineDatabaseEngine: PipelineDatabaseEngine, projectE
   def getProjectById(projectId: ProjectId): Future[Option[Project]] =
     database.run(projectEntry.getProjectByIdAction(projectId).result.headOption)
 
-  def getProjectByName(name: String): Future[Option[Project]] =
-    database.run(projectEntry.getProjectByNameAction(name).result.headOption)
+  def getProjectsByName(name: String): Future[Seq[Project]] =
+    database.run(projectEntry.getProjectsByNameAction(name).result)
 
   def addProject(project: Project): Future[ProjectId] = database.run(projectEntry.addProjectAction(project))
 


### PR DESCRIPTION
**DESCRIPTION**

Right now ProjectRepository.getProjectByName returns option of single project
Theoretically, it's possible that several projects may have the same name (or the same name pattern), and the first found project would be authored by another user (not the one who called the method), and as a result user won't get the project (even he is an author of one of such projects).

**CHANGES**
- ProjectEntry.scala, ProjectRepository.scala, ProjectService.scala, ProjectControllerItTest.scala and ProjectServiceTest.scala have been updated.
- Now a query to the database gives out a sequence of projects, it allows to get a project by name with current userId. Therefore we can avoid  getting of project with random (inappropriate) userId at database level.