### PR TITLE
EPMLSTRCMW-232 fix: Add configurations versioning

### DIFF
--- a/controllers/src/main/scala/cromwell/pipeline/controller/ProjectConfigurationController.scala
+++ b/controllers/src/main/scala/cromwell/pipeline/controller/ProjectConfigurationController.scala
@@ -26,7 +26,7 @@ class ProjectConfigurationController(projectConfigurationService: ProjectConfigu
 
   private def getConfiguration(implicit accessToken: AccessTokenContent): Route = get {
     parameter('project_id.as[String]) { projectId =>
-      onComplete(projectConfigurationService.getConfigurationById(ProjectId(projectId), accessToken.userId)) {
+      onComplete(projectConfigurationService.getLastByProjectId(ProjectId(projectId), accessToken.userId)) {
         case Failure(e)                   => complete(StatusCodes.InternalServerError, e.getMessage)
         case Success(Some(configuration)) => complete(configuration)
         case Success(None) =>
@@ -37,7 +37,7 @@ class ProjectConfigurationController(projectConfigurationService: ProjectConfigu
 
   private def deactivateConfiguration(implicit accessToken: AccessTokenContent): Route = delete {
     parameter('project_id.as[String]) { projectId =>
-      onComplete(projectConfigurationService.deactivateConfiguration(ProjectId(projectId), accessToken.userId)) {
+      onComplete(projectConfigurationService.deactivateLastByProjectId(ProjectId(projectId), accessToken.userId)) {
         case Failure(e) => complete(StatusCodes.InternalServerError, e.getMessage)
         case Success(_) => complete(StatusCodes.NoContent)
       }

--- a/controllers/src/test/scala/cromwell/pipeline/controller/ProjectFileControllerTest.scala
+++ b/controllers/src/test/scala/cromwell/pipeline/controller/ProjectFileControllerTest.scala
@@ -84,8 +84,10 @@ class ProjectFileControllerTest extends AsyncWordSpec with Matchers with Scalate
       val versionString = "v0.0.2"
       val versionOption = Some(PipelineVersion("v0.0.2"))
       val projectId = TestProjectUtils.getDummyProjectId
+      val projectConfigurationId = ProjectConfigurationId.randomId
       val path = "/home/test/file"
       val configuration = ProjectConfiguration(
+        projectConfigurationId,
         projectId,
         active = true,
         List(
@@ -93,7 +95,8 @@ class ProjectFileControllerTest extends AsyncWordSpec with Matchers with Scalate
             Paths.get(path),
             List(FileParameter("nodeName", StringTyped(Some("hello"))))
           )
-        )
+        ),
+        ProjectConfigurationVersion.defaultVersion
       )
 
       "return configuration for file" in {

--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/dao/repository/ProjectConfigurationRepository.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/dao/repository/ProjectConfigurationRepository.scala
@@ -2,14 +2,14 @@ package cromwell.pipeline.datastorage.dao.repository
 
 import cromwell.pipeline.datastorage.dao.mongo.DocumentCodecInstances.projectConfigurationDocumentCodec
 import cromwell.pipeline.datastorage.dao.mongo.DocumentRepository
-import cromwell.pipeline.datastorage.dto.{ ProjectConfiguration, ProjectId }
+import cromwell.pipeline.datastorage.dto.{ ProjectConfiguration, ProjectConfigurationId, ProjectId }
 
 import scala.concurrent.{ ExecutionContext, Future }
 
 class ProjectConfigurationRepository(repository: DocumentRepository)(implicit ec: ExecutionContext) {
 
   private def upsertConfiguration(projectConfiguration: ProjectConfiguration): Future[Unit] =
-    repository.upsertOne(projectConfiguration, "projectId", projectConfiguration.projectId.value)
+    repository.upsertOne(projectConfiguration, "id", projectConfiguration.id.value)
 
   def addConfiguration(projectConfiguration: ProjectConfiguration): Future[Unit] =
     upsertConfiguration(projectConfiguration)
@@ -17,6 +17,9 @@ class ProjectConfigurationRepository(repository: DocumentRepository)(implicit ec
   def updateConfiguration(projectConfiguration: ProjectConfiguration): Future[Unit] =
     upsertConfiguration(projectConfiguration)
 
-  def getById(projectId: ProjectId): Future[Option[ProjectConfiguration]] =
-    repository.getByParam("projectId", projectId.value).map(_.headOption)
+  def getById(id: ProjectConfigurationId): Future[Option[ProjectConfiguration]] =
+    repository.getByParam("id", id.value).map(_.headOption)
+
+  def getAllByProjectId(projectId: ProjectId): Future[Seq[ProjectConfiguration]] =
+    repository.getByParam("projectId", projectId.value)
 }

--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/ProjectConfiguration.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/ProjectConfiguration.scala
@@ -1,9 +1,13 @@
 package cromwell.pipeline.datastorage.dto
 
 import java.nio.file.Path
-
 import ProjectFile.pathFormat
-import play.api.libs.json.{ Json, OFormat }
+import cats.data.Validated
+import cromwell.pipeline.model.wrapper.VersionValue
+import play.api.libs.functional.syntax.toInvariantFunctorOps
+import play.api.libs.json.{ Format, Json, OFormat }
+
+import java.util.UUID
 
 case class ProjectFileConfiguration(path: Path, inputs: List[FileParameter])
 
@@ -11,10 +15,59 @@ object ProjectFileConfiguration {
   implicit val projectFileConfigurationFormat: OFormat[ProjectFileConfiguration] = Json.format
 }
 
+final case class ProjectConfigurationVersion(value: VersionValue) extends Ordered[ProjectConfigurationVersion] {
+  import VersionValue._
+
+  def name: String = s"v$value"
+
+  private val ordering: Ordering[ProjectConfigurationVersion] = Ordering.by(v => v.value)
+
+  override def compare(that: ProjectConfigurationVersion): Int = ordering.compare(this, that)
+
+  def increaseValue: ProjectConfigurationVersion =
+    this.copy(value = increment(this.value))
+
+  override def toString: String = this.name
+}
+
+object ProjectConfigurationVersion {
+  import VersionValue._
+
+  def defaultVersion: ProjectConfigurationVersion = apply("v1")
+
+  private val pattern = "^v(.+)$".r
+
+  def apply(versionLine: String): ProjectConfigurationVersion =
+    versionLine match {
+      case pattern(version) =>
+        val validationResult = fromString(version).map(ProjectConfigurationVersion.apply)
+        validationResult match {
+          case Validated.Valid(content)  => content
+          case Validated.Invalid(errors) => throw ProjectConfigurationVersionException(errors.toString)
+        }
+      case _ => throw ProjectConfigurationVersionException(s"Format of version name: 'v(int)', but got: $versionLine")
+    }
+
+  final case class ProjectConfigurationVersionException(message: String) extends Exception
+
+  implicit val projectConfigurationVersionFormat: Format[ProjectConfigurationVersion] =
+    implicitly[Format[String]].inmap(ProjectConfigurationVersion.apply, _.name)
+}
+
+final case class ProjectConfigurationId(value: String)
+
+object ProjectConfigurationId {
+  def randomId: ProjectConfigurationId = ProjectConfigurationId(UUID.randomUUID().toString)
+  implicit lazy val configurationIdFormat: Format[ProjectConfigurationId] =
+    implicitly[Format[String]].inmap(ProjectConfigurationId.apply, _.value)
+}
+
 case class ProjectConfiguration(
+  id: ProjectConfigurationId,
   projectId: ProjectId,
   active: Boolean,
-  projectFileConfigurations: List[ProjectFileConfiguration]
+  projectFileConfigurations: List[ProjectFileConfiguration],
+  version: ProjectConfigurationVersion
 )
 
 object ProjectConfiguration {

--- a/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/utils/GeneratorUtils.scala
+++ b/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/utils/GeneratorUtils.scala
@@ -23,6 +23,9 @@ object GeneratorUtils {
 
   private lazy val projectIdGen: Gen[ProjectId] = Gen.uuid.map(id => ProjectId(id.toString))
 
+  private lazy val projectConfigurationIdGen: Gen[ProjectConfigurationId] =
+    Gen.uuid.map(id => ProjectConfigurationId(id.toString))
+
   private lazy val emailGen: Gen[UserEmail] = for {
     name <- stringGen()
     mail <- Gen.oneOf(Mail.values.toSeq)
@@ -44,6 +47,10 @@ object GeneratorUtils {
     minor <- versionValueGen
     revision <- versionValueGen
   } yield PipelineVersion(major, minor, revision)
+
+  private lazy val projectConfigurationVersionGen: Gen[ProjectConfigurationVersion] = for {
+    version <- versionValueGen
+  } yield ProjectConfigurationVersion(version)
 
   private lazy val passwordGen: Gen[Password] = for {
     upperCase <- Gen.alphaUpperStr.suchThat(s => s.nonEmpty)
@@ -128,10 +135,12 @@ object GeneratorUtils {
   } yield ProjectFileConfiguration(path, fileParameters)
 
   lazy val projectConfigurationGen: Gen[ProjectConfiguration] = for {
+    id <- projectConfigurationIdGen
     projectId <- projectIdGen
     active <- booleanGen
     projectFileConfigurations <- listOfN(projectFileConfigurationGen)
-  } yield ProjectConfiguration(projectId, active, projectFileConfigurations)
+    version <- projectConfigurationVersionGen
+  } yield ProjectConfiguration(id, projectId, active, projectFileConfigurations, version)
 
   object Mail extends Enumeration {
     val Mail, Gmail, Epam, Yandex = Value

--- a/services/src/main/scala/cromwell/pipeline/service/AggregationService.scala
+++ b/services/src/main/scala/cromwell/pipeline/service/AggregationService.scala
@@ -18,10 +18,11 @@ class AggregationService(
     val version = PipelineVersion(run.projectVersion)
     val projectFiles =
       getFilesByProjectId(run.projectId, run.userId, Some(version)).valueOrF(e => Future.failed(e))
-    val futureFileConfigurations = projectConfigurationService.getConfigurationById(run.projectId, run.userId).flatMap {
-      case Some(config) => Future.successful(config.projectFileConfigurations)
-      case None         => Future.failed(new RuntimeException("Configurations for projectId " + run.projectId + " not found"))
-    }
+    val futureFileConfigurations =
+      projectConfigurationService.getLastByProjectId(run.projectId, run.userId).flatMap {
+        case Some(config) => Future.successful(config.projectFileConfigurations)
+        case None         => Future.failed(new RuntimeException("Configurations for projectId " + run.projectId + " not found"))
+      }
     for {
       files <- projectFiles
       configs <- futureFileConfigurations

--- a/services/src/main/scala/cromwell/pipeline/service/ServiceModule.scala
+++ b/services/src/main/scala/cromwell/pipeline/service/ServiceModule.scala
@@ -20,10 +20,9 @@ class ServiceModule(
   lazy val userService: UserService = new UserService(datastorageModule.userRepository)
   lazy val projectVersioning: GitLabProjectVersioning = new GitLabProjectVersioning(httpClient, config)
   lazy val projectService: ProjectService = new ProjectService(datastorageModule.projectRepository, projectVersioning)
-
-  lazy val projectFileService: ProjectFileService =
-    new ProjectFileService(projectService, womToolModule.womTool, projectVersioning)
   lazy val configurationService =
     new ProjectConfigurationService(datastorageModule.configurationRepository, projectService)
+  lazy val projectFileService: ProjectFileService =
+    new ProjectFileService(projectService, configurationService, womToolModule.womTool, projectVersioning)
   lazy val runService: RunService = new RunService(datastorageModule.runRepository)
 }


### PR DESCRIPTION
**DESCRIPTION**

Currently we don't have versioning for ProjectFileConfiguration. Only one latest version is available for the user.
Since we're versioning project files, it is good idea to do versioning for the ProjectFileConfiguration as well.

**CHANGES**

The version field has been added to the ProjectConfiguration object. Now, when calling buildConfiguration, an object with a new version is returned to us. The old version remains unchanged. We can also deactivate the current version and in general any. the client will be given the last active one.

