### PR TITLE
EPMLSTRCMW-236

### DIFF
--- a/model/src/main/scala/cromwell/pipeline/model/wrapper/VersionValue.scala
+++ b/model/src/main/scala/cromwell/pipeline/model/wrapper/VersionValue.scala
@@ -14,6 +14,7 @@ object VersionValue extends Wrapped.Companion {
   val pattern = "^[0-9]+$"
   implicit val versionNumberFormat: Format[VersionValue] = wrapperFormat
   def increment(value: VersionValue): VersionValue = create(value.unwrap + 1)
+  def resetValue: VersionValue = create(0)
   def fromString(value: String): ValidationResult[Wrapper] =
     validateString(value) match {
       case Validated.Valid(content)  => Validated.Valid(create(content.toInt))

--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/Project.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/Project.scala
@@ -110,10 +110,10 @@ final case class PipelineVersion(major: VersionValue, minor: VersionValue, revis
     ordering.compare(this, that)
 
   def increaseMajor: PipelineVersion =
-    this.copy(major = increment(this.major))
+    this.copy(major = increment(this.major), minor = resetValue, revision = resetValue)
 
   def increaseMinor: PipelineVersion =
-    this.copy(minor = increment(this.minor))
+    this.copy(minor = increment(this.minor), revision = resetValue)
 
   def increaseRevision: PipelineVersion =
     this.copy(revision = increment(this.revision))

--- a/repositories/src/test/scala/cromwell/pipeline/datastorage/dto/Dto.scala
+++ b/repositories/src/test/scala/cromwell/pipeline/datastorage/dto/Dto.scala
@@ -1,0 +1,4 @@
+package cromwell.pipeline.datastorage.dto
+import org.scalatest.Tag
+
+object Dto extends Tag("cromwell.pipeline.tag.Dto")

--- a/repositories/src/test/scala/cromwell/pipeline/datastorage/dto/PipelineVersionTest.scala
+++ b/repositories/src/test/scala/cromwell/pipeline/datastorage/dto/PipelineVersionTest.scala
@@ -1,0 +1,58 @@
+package cromwell.pipeline.datastorage.dto
+
+import cromwell.pipeline.datastorage.dto.PipelineVersion.PipelineVersionException
+import org.scalatest.{ Matchers, WordSpec }
+
+class PipelineVersionTest extends WordSpec with Matchers {
+  "PipelineVersion" when {
+
+    "apply method" should {
+      "return correct PipelineVersion" taggedAs Dto in {
+        val version = PipelineVersion("v1.2.3")
+        val expectedName = "v1.2.3"
+
+        version.name shouldBe expectedName
+        version.major.unwrap shouldBe 1
+        version.minor.unwrap shouldBe 2
+        version.revision.unwrap shouldBe 3
+      }
+
+      "throw PipelineVersionException due to invalid constructor parameter in apply method" taggedAs Dto in {
+        val versionLine = "1.2"
+        val caught = intercept[PipelineVersionException] {
+          PipelineVersion(versionLine)
+        }
+
+        caught.message shouldBe s"Format of version name: 'v(int).(int).(int)', but got: $versionLine"
+      }
+
+    }
+
+    "increasing of major member" should {
+      "increase major and reset minor with revision members" taggedAs Dto in {
+        val version = PipelineVersion("v1.2.3")
+        val updatedVersion = PipelineVersion("v2.0.0")
+
+        version.increaseMajor shouldBe updatedVersion
+      }
+    }
+
+    "increasing of minor member" should {
+      "increase minor and reset revision members" taggedAs Dto in {
+        val version = PipelineVersion("v1.2.3")
+        val updatedVersion = PipelineVersion("v1.3.0")
+
+        version.increaseMinor shouldBe updatedVersion
+      }
+    }
+
+    "increasing of revision member" should {
+      "increase revision member" taggedAs Dto in {
+        val version = PipelineVersion("v1.2.3")
+        val updatedVersion = PipelineVersion("v1.2.4")
+
+        version.increaseRevision shouldBe updatedVersion
+      }
+    }
+  }
+}


### PR DESCRIPTION
**DESCRIPTION**

- Right now when we increase manor/major version, child version doesn't change.

**CHANGES**

- Project.scala and VersionValue.scala have been updated
- Now if we increment the older member in the version the previous younger members must reset their values. For example we have version 1.2.3 [major.minor.revision] when increasing 
1) the major member we should get next version of 2.0.0
2) the minor member -> 1.3.0
3) the revision member -> 1.2.4

