### PR TITLE
EPMLSTRCMW-250 feat: Add CORS support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,4 @@ CMWL_MONGO_COLLECTION=configurations
 CMWL_GITLAB_USER_NAME=root
 CMWL_GITLAB_TOKEN=!!put_here_correct_token!!
 CMWL_GITLAB_URL=http://gitlab:9080/api/v4/
+CMWL_CORS_ALLOWED_ORIGINS=["http://localhost:3000"]

--- a/build.sbt
+++ b/build.sbt
@@ -59,7 +59,7 @@ lazy val portal = project
   .settings(
     name := "Portal",
     commonSettings,
-    libraryDependencies ++= akkaDependencies ++ jsonDependencies ++ logDependencies :+ configHokon :+ akkaHttpCore,
+    libraryDependencies ++= akkaDependencies ++ jsonDependencies ++ logDependencies :+ configHokon :+ akkaHttpCore :+ akkaHttpCors,
     Defaults.itSettings,
     Seq(parallelExecution in Test := false),
     addCommandAlias("testAll", "; test ; it:test"),

--- a/portal/src/it/resources/application.conf
+++ b/portal/src/it/resources/application.conf
@@ -1,6 +1,9 @@
 webservice {
   interface = "localhost"
   port = 8080
+  cors {
+    allowedOrigins = [ "http://localhost:3000" ]
+  }
 }
 
 auth {
@@ -42,12 +45,19 @@ database {
   }
 
   mongo {
+    user = "mongoUser"
     user = ${?CMWL_TEST_MONGO_USER}
+    password = "password"
     password = ${?CMWL_TEST_MONGO_PASSWORD}
+    host = "localhost"
     host = ${?CMWL_TEST_MONGO_HOST}
+    port = "27017"
     port = ${?CMWL_TEST_MONGO_PORT}
+    authenticationDatabase = "admin"
     authenticationDatabase = ${?CMWL_TEST_MONGO_AUTH}
+    database = "mongo"
     database = ${?CMWL_TEST_MONGO_DB}
+    collection = "configurations"
     collection = ${?CMWL_TEST_MONGO_COLLECTION}
   }
 }

--- a/portal/src/it/scala/AkkaHttpCorsItTest.scala
+++ b/portal/src/it/scala/AkkaHttpCorsItTest.scala
@@ -1,0 +1,54 @@
+import akka.http.scaladsl.model.ContentTypes.`application/json`
+import akka.http.scaladsl.model.headers.{HttpOrigin, Origin}
+import akka.http.scaladsl.model.{HttpEntity, StatusCodes}
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import ch.megard.akka.http.cors.scaladsl.CorsRejection
+import ch.megard.akka.http.cors.scaladsl.CorsRejection.InvalidOrigin
+import com.dimafeng.testcontainers.{ForAllTestContainer, PostgreSQLContainer}
+import com.typesafe.config.Config
+import cromwell.pipeline.datastorage.dao.utils.TestUserUtils
+import cromwell.pipeline.datastorage.dao.utils.TestUserUtils.userPassword
+import cromwell.pipeline.datastorage.dto.User
+import cromwell.pipeline.utils.TestContainersUtils
+import cromwell.pipeline.{ApplicationComponents, CromwellPipelineRoute}
+import org.scalatest.{Matchers, WordSpec}
+
+class AkkaHttpCorsItTest extends WordSpec with Matchers with ScalatestRouteTest with ForAllTestContainer {
+
+  override val container: PostgreSQLContainer = TestContainersUtils.getPostgreSQLContainer()
+  private implicit lazy val config: Config = TestContainersUtils.getConfigForPgContainer(container)
+  private lazy val components: ApplicationComponents = new ApplicationComponents()
+  private lazy val route = new CromwellPipelineRoute(components.applicationConfig, components.controllerModule).route
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    components.datastorageModule.pipelineDatabaseEngine.updateSchema()
+  }
+
+  "CORS" should {
+    "allow requests with allowed origin" in {
+      val dummyUser: User = TestUserUtils.getDummyUser()
+      val signUpRequestStr =
+        s"""{"email":"${dummyUser.email}","password":"${userPassword}","firstName":"${dummyUser.firstName}","lastName":"${dummyUser.lastName}"}"""
+      val httpEntity: HttpEntity.Strict = HttpEntity(`application/json`, signUpRequestStr)
+      val allowedOrigin = components.applicationConfig.webServiceConfig.cors.allowedOrigins.head
+
+      Post("/auth/signUp", httpEntity) ~> Origin(HttpOrigin(allowedOrigin)) ~> route ~> check {
+        status shouldBe StatusCodes.OK
+      }
+    }
+
+    "reject requests with not allowed origin" in {
+      val dummyUser: User = TestUserUtils.getDummyUser()
+      val signUpRequestStr =
+        s"""{"email":"${dummyUser.email}","password":"${userPassword}","firstName":"${dummyUser.firstName}","lastName":"${dummyUser.lastName}"}"""
+      val httpEntity: HttpEntity.Strict = HttpEntity(`application/json`, signUpRequestStr)
+      val notAllowedOrigin = "http://not_allowed_origin:3000"
+
+      Post("/auth/signUp", httpEntity) ~> Origin(HttpOrigin(notAllowedOrigin)) ~> route ~> check {
+        rejection shouldEqual CorsRejection(InvalidOrigin(List(notAllowedOrigin)))
+      }
+    }
+  }
+
+}

--- a/portal/src/main/resources/application.conf
+++ b/portal/src/main/resources/application.conf
@@ -4,6 +4,10 @@ webservice {
   // Docker has no "localhost" inside and it generates its own host (e.g. http://e30590c064c6:8080/)
   interface = ${?HOSTNAME}
   port = 8080
+  cors {
+    allowedOrigins = []
+    allowedOrigins = [ ${?CMWL_CORS_ALLOWED_ORIGINS} ]
+  }
 }
 
 auth {

--- a/portal/src/main/scala/cromwell/pipeline/CromwellPipelineApp.scala
+++ b/portal/src/main/scala/cromwell/pipeline/CromwellPipelineApp.scala
@@ -4,9 +4,8 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives._
-import akka.http.scaladsl.server.{ RejectionHandler, Route, ValidationRejection }
+import akka.http.scaladsl.server.{ RejectionHandler, ValidationRejection }
 import cromwell.pipeline.auth.token.MissingAccessTokenRejection
-import cromwell.pipeline.datastorage.dto.auth.AccessTokenContent
 import cromwell.pipeline.utils.configs.ConfigJsonOps
 import org.slf4j.LoggerFactory
 
@@ -28,29 +27,16 @@ object CromwellPipelineApp extends App {
     .result()
     .withFallback(RejectionHandler.default)
 
-  type SecuredRoute = AccessTokenContent => Route
-
-  def routeCombiner(routes: SecuredRoute*): SecuredRoute = token => concat(routes.map(_(token)): _*)
-
   Try {
     val components = new ApplicationComponents()
 
     import components.applicationConfig
     import components.applicationConfig.webServiceConfig
-    import components.controllerModule._
     import components.datastorageModule._
 
     pipelineDatabaseEngine.updateSchema()
 
-    val route = authController.route ~ securityDirective.authenticated {
-      routeCombiner(
-        userController.route,
-        projectController.route,
-        projectFileController.route,
-        runController.route,
-        configurationController.route
-      )
-    }
+    val route = new CromwellPipelineRoute(components.applicationConfig, components.controllerModule).route
 
     log.info(s"Server online at http://${webServiceConfig.interface}:${webServiceConfig.port}/")
     log.info(ConfigJsonOps.configToJsonString(applicationConfig))

--- a/portal/src/main/scala/cromwell/pipeline/CromwellPipelineRoute.scala
+++ b/portal/src/main/scala/cromwell/pipeline/CromwellPipelineRoute.scala
@@ -1,0 +1,37 @@
+package cromwell.pipeline
+
+import akka.http.scaladsl.model.headers.HttpOrigin
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+import ch.megard.akka.http.cors.javadsl.model.HttpOriginMatcher
+import ch.megard.akka.http.cors.scaladsl.settings.CorsSettings
+import cromwell.pipeline.controller.ControllerModule
+import cromwell.pipeline.datastorage.dto.auth.AccessTokenContent
+import cromwell.pipeline.utils.ApplicationConfig
+
+object CromwellPipelineRoute {
+  type SecuredRoute = AccessTokenContent => Route
+  def routeCombiner(routes: SecuredRoute*): SecuredRoute = token => concat(routes.map(_(token)): _*)
+}
+
+final class CromwellPipelineRoute(applicationConfig: ApplicationConfig, controllerModule: ControllerModule) {
+  import CromwellPipelineRoute._
+  import ch.megard.akka.http.cors.scaladsl.CorsDirectives._
+  import controllerModule._
+
+  private val allowedOrigins = applicationConfig.webServiceConfig.cors.allowedOrigins.map(HttpOrigin(_))
+  private val httpOriginMatcher = HttpOriginMatcher.create(allowedOrigins: _*)
+  private val corsSettings = CorsSettings.defaultSettings.withAllowedOrigins(httpOriginMatcher)
+
+  val route: Route = cors(corsSettings) {
+    authController.route ~ securityDirective.authenticated {
+      routeCombiner(
+        userController.route,
+        projectController.route,
+        projectFileController.route,
+        runController.route,
+        configurationController.route
+      )
+    }
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,6 +5,7 @@ object Dependencies {
   object Version {
     val akka = "2.6.12"
     val akkaHttp = "10.2.3"
+    val akkaHttpCors = "1.1.1"
     val slick = "3.3.3"
     val slickPg = "0.19.4"
     val hikariCP = "3.3.3"
@@ -34,6 +35,7 @@ object Dependencies {
   val akkaStreams = "com.typesafe.akka" %% "akka-stream" % Version.akka
   val akkaHttp = "com.typesafe.akka" %% "akka-http" % Version.akkaHttp
   val akkaHttpCore = "com.typesafe.akka" %% "akka-http-core" % Version.akkaHttp
+  val akkaHttpCors = "ch.megard" %% "akka-http-cors" % Version.akkaHttpCors
   val slick = "com.typesafe.slick" %% "slick" % Version.slick
   val slickPg = "com.github.tminglei" %% "slick-pg" % Version.slickPg
   val slickPgCore = "com.github.tminglei" %% "slick-pg_core" % Version.slickPg

--- a/utils/src/main/scala/cromwell/pipeline/utils/configs/ConfigJsonOps.scala
+++ b/utils/src/main/scala/cromwell/pipeline/utils/configs/ConfigJsonOps.scala
@@ -16,9 +16,13 @@ object ConfigJsonOps extends ConfigJsonOps {
 
     val secretCAWrites: Writes[SecretData[Array[Char]]] = secretDataWrites(Writes.StringWrites.contramap(new String(_)))
 
+    implicit val akkaHttpCorsWrites: Writes[CorsConfig] =
+      (__ \ "allowedOrigins").write[Seq[String]].contramap[CorsConfig](_.allowedOrigins)
+
     implicit val wsWrites: Writes[WebServiceConfig] =
       ((__ \ "interface").write[String] ~
-        (__ \ "port").write[Int])(unlift(WebServiceConfig.unapply))
+        (__ \ "port").write[Int] ~
+        (__ \ "cors").write[CorsConfig])(unlift(WebServiceConfig.unapply))
 
     implicit val expTimeWrites: Writes[ExpirationTimeInSeconds] =
       ((__ \ "accessToken").write[Long] ~

--- a/utils/src/test/scala/cromwell/pipeline/utils/configs/ConfigJsonOpsTest.scala
+++ b/utils/src/test/scala/cromwell/pipeline/utils/configs/ConfigJsonOpsTest.scala
@@ -11,6 +11,9 @@ class ConfigJsonOpsTest extends WordSpec {
     s"""webservice {
        |  interface = "wsInterface"
        |  port = 4040
+       |  cors {
+       |    allowedOrigins = [ "http://localhost:3000" ]
+       |  }
        |}
        |auth {
        |  secretKey = "authSecretKey"
@@ -56,6 +59,9 @@ class ConfigJsonOpsTest extends WordSpec {
     s"""webservice {
        |  interface = "wsInterface"
        |  port = 4040
+       |  cors {
+       |    allowedOrigins = [ "http://localhost:3000" ]
+       |  }
        |}
        |auth {
        |  secretKey = ""
@@ -105,7 +111,10 @@ class ConfigJsonOpsTest extends WordSpec {
        |{
        |  "WebServiceConfig" : {
        |    "interface" : "wsInterface",
-       |    "port" : 4040
+       |    "port" : 4040,
+       |    "cors" : {
+       |      "allowedOrigins" : [ "http://localhost:3000" ]
+       |    }
        |  },
        |  "AuthConfig" : {
        |    "secretKey" : "*********",
@@ -150,7 +159,10 @@ class ConfigJsonOpsTest extends WordSpec {
        |{
        |  "WebServiceConfig" : {
        |    "interface" : "wsInterface",
-       |    "port" : 4040
+       |    "port" : 4040,
+       |    "cors" : {
+       |      "allowedOrigins" : [ "http://localhost:3000" ]
+       |    }
        |  },
        |  "AuthConfig" : {
        |    "secretKey" : "",


### PR DESCRIPTION
**DESCRIPTION**

In order to allow requests from the frontend side, we need to enable cross-origin requests.

**CHANGES**

- The akka-http-cors dependency was added
- The cors directive was added to the main app route
- In order to test that CORS was enabled for the main app route its definition has been moved into a separate class for convenience
- Test on enabled CORS was added
- The `ConfigJsonOps` and `ApplicationConfig` was extended
- The `ConfigJsonOpsTest` was updated
- The `.env.example` was updated