### PR TITLE
EPMLSTRCMW-252 feat: Expose auth headers

### DIFF
--- a/portal/src/it/scala/AkkaHttpCorsItTest.scala
+++ b/portal/src/it/scala/AkkaHttpCorsItTest.scala
@@ -1,17 +1,18 @@
 import akka.http.scaladsl.model.ContentTypes.`application/json`
-import akka.http.scaladsl.model.headers.{HttpOrigin, Origin}
-import akka.http.scaladsl.model.{HttpEntity, StatusCodes}
+import akka.http.scaladsl.model.headers.{ HttpOrigin, Origin, `Access-Control-Expose-Headers` }
+import akka.http.scaladsl.model.{ HttpEntity, StatusCodes }
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import ch.megard.akka.http.cors.scaladsl.CorsRejection
 import ch.megard.akka.http.cors.scaladsl.CorsRejection.InvalidOrigin
-import com.dimafeng.testcontainers.{ForAllTestContainer, PostgreSQLContainer}
+import com.dimafeng.testcontainers.{ ForAllTestContainer, PostgreSQLContainer }
 import com.typesafe.config.Config
+import cromwell.pipeline.controller.AuthController._
 import cromwell.pipeline.datastorage.dao.utils.TestUserUtils
 import cromwell.pipeline.datastorage.dao.utils.TestUserUtils.userPassword
 import cromwell.pipeline.datastorage.dto.User
 import cromwell.pipeline.utils.TestContainersUtils
-import cromwell.pipeline.{ApplicationComponents, CromwellPipelineRoute}
-import org.scalatest.{Matchers, WordSpec}
+import cromwell.pipeline.{ ApplicationComponents, CromwellPipelineRoute }
+import org.scalatest.{ Matchers, WordSpec }
 
 class AkkaHttpCorsItTest extends WordSpec with Matchers with ScalatestRouteTest with ForAllTestContainer {
 
@@ -20,6 +21,12 @@ class AkkaHttpCorsItTest extends WordSpec with Matchers with ScalatestRouteTest 
   private lazy val components: ApplicationComponents = new ApplicationComponents()
   private lazy val route = new CromwellPipelineRoute(components.applicationConfig, components.controllerModule).route
 
+  private val dummyUser: User = TestUserUtils.getDummyUser()
+  private val signUpRequestStr =
+    s"""{"email":"${dummyUser.email}","password":"$userPassword","firstName":"${dummyUser.firstName}","lastName":"${dummyUser.lastName}"}"""
+  private val httpEntity: HttpEntity.Strict = HttpEntity(`application/json`, signUpRequestStr)
+  private lazy val allowedOrigin: String = components.applicationConfig.webServiceConfig.cors.allowedOrigins.head
+
   override protected def beforeAll(): Unit = {
     super.beforeAll()
     components.datastorageModule.pipelineDatabaseEngine.updateSchema()
@@ -27,26 +34,24 @@ class AkkaHttpCorsItTest extends WordSpec with Matchers with ScalatestRouteTest 
 
   "CORS" should {
     "allow requests with allowed origin" in {
-      val dummyUser: User = TestUserUtils.getDummyUser()
-      val signUpRequestStr =
-        s"""{"email":"${dummyUser.email}","password":"${userPassword}","firstName":"${dummyUser.firstName}","lastName":"${dummyUser.lastName}"}"""
-      val httpEntity: HttpEntity.Strict = HttpEntity(`application/json`, signUpRequestStr)
-      val allowedOrigin = components.applicationConfig.webServiceConfig.cors.allowedOrigins.head
-
       Post("/auth/signUp", httpEntity) ~> Origin(HttpOrigin(allowedOrigin)) ~> route ~> check {
         status shouldBe StatusCodes.OK
       }
     }
 
     "reject requests with not allowed origin" in {
-      val dummyUser: User = TestUserUtils.getDummyUser()
-      val signUpRequestStr =
-        s"""{"email":"${dummyUser.email}","password":"${userPassword}","firstName":"${dummyUser.firstName}","lastName":"${dummyUser.lastName}"}"""
-      val httpEntity: HttpEntity.Strict = HttpEntity(`application/json`, signUpRequestStr)
       val notAllowedOrigin = "http://not_allowed_origin:3000"
 
       Post("/auth/signUp", httpEntity) ~> Origin(HttpOrigin(notAllowedOrigin)) ~> route ~> check {
         rejection shouldEqual CorsRejection(InvalidOrigin(List(notAllowedOrigin)))
+      }
+    }
+
+    "expose auth headers" in {
+      val authHeaders = List(AccessTokenHeader, RefreshTokenHeader, AccessTokenExpirationHeader)
+
+      Post("/auth/signUp", httpEntity) ~> Origin(HttpOrigin(allowedOrigin)) ~> route ~> check {
+        response.headers should contain(`Access-Control-Expose-Headers`(authHeaders))
       }
     }
   }

--- a/portal/src/main/scala/cromwell/pipeline/CromwellPipelineRoute.scala
+++ b/portal/src/main/scala/cromwell/pipeline/CromwellPipelineRoute.scala
@@ -16,12 +16,16 @@ object CromwellPipelineRoute {
 
 final class CromwellPipelineRoute(applicationConfig: ApplicationConfig, controllerModule: ControllerModule) {
   import CromwellPipelineRoute._
+  import applicationConfig.webServiceConfig.{ cors => appConfigCors }
   import ch.megard.akka.http.cors.scaladsl.CorsDirectives._
   import controllerModule._
+  import cromwell.pipeline.controller.AuthController._
 
-  private val allowedOrigins = applicationConfig.webServiceConfig.cors.allowedOrigins.map(HttpOrigin(_))
+  private val allowedOrigins = appConfigCors.allowedOrigins.map(HttpOrigin(_))
   private val httpOriginMatcher = HttpOriginMatcher.create(allowedOrigins: _*)
-  private val corsSettings = CorsSettings.defaultSettings.withAllowedOrigins(httpOriginMatcher)
+  private val authHeaders = List(AccessTokenHeader, RefreshTokenHeader, AccessTokenExpirationHeader)
+  private val corsSettings =
+    CorsSettings.defaultSettings.withAllowedOrigins(httpOriginMatcher).withExposedHeaders(authHeaders)
 
   val route: Route = cors(corsSettings) {
     authController.route ~ securityDirective.authenticated {

--- a/utils/src/main/scala/cromwell/pipeline/utils/configs/ConfigJsonOps.scala
+++ b/utils/src/main/scala/cromwell/pipeline/utils/configs/ConfigJsonOps.scala
@@ -16,7 +16,7 @@ object ConfigJsonOps extends ConfigJsonOps {
 
     val secretCAWrites: Writes[SecretData[Array[Char]]] = secretDataWrites(Writes.StringWrites.contramap(new String(_)))
 
-    implicit val akkaHttpCorsWrites: Writes[CorsConfig] =
+    implicit val corsWrites: Writes[CorsConfig] =
       (__ \ "allowedOrigins").write[Seq[String]].contramap[CorsConfig](_.allowedOrigins)
 
     implicit val wsWrites: Writes[WebServiceConfig] =


### PR DESCRIPTION
**DESCRIPTION**

In order to receive auth headers on the frontend side, we need to expose them.

**CHANGES**

- Auth headers were exposed
- Test on exposed auth headers was added
- `akkaHttpCorsWrites` variable was renamed to `corsWrites` in the `ConfigJsonOps`