### PR TITLE
EPMLSTRCMW-203 Fix: Flaky tests in RepositoryTest

### DIFF
--- a/repositories/src/test/resources/application.conf
+++ b/repositories/src/test/resources/application.conf
@@ -39,5 +39,6 @@ database {
 
   liquibase {
     changeLogResourcePath = "liquibase/changelog/changelog-master.xml"
+    changeLogCleanTablesResourcePath = "liquibase/changelogs/changelog-cleanTables.xml"
   }
 }

--- a/repositories/src/test/resources/liquibase/changelogs/changelog-cleanTables.xml
+++ b/repositories/src/test/resources/liquibase/changelogs/changelog-cleanTables.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <changeSet author="nisaev" id="clean_tables" runAlways="true">
+
+        <sqlFile path="liquibase/sql/clean-tables.sql" splitStatements="false"/>
+
+    </changeSet>
+
+</databaseChangeLog>

--- a/repositories/src/test/resources/liquibase/sql/clean-tables.sql
+++ b/repositories/src/test/resources/liquibase/sql/clean-tables.sql
@@ -1,0 +1,12 @@
+DO
+$func$
+BEGIN
+EXECUTE
+    (SELECT 'TRUNCATE TABLE ' || string_agg(oid::regclass::text, ', ') || ' CASCADE'
+     FROM pg_class
+     WHERE relkind = 'r' -- 'r' stands for "ordinary table" kind
+       AND relname NOT IN ('databasechangelog', 'databasechangeloglock')
+       AND relnamespace = 'public'::regnamespace
+    );
+END
+$func$;

--- a/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/RunRepositoryTest.scala
+++ b/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/RunRepositoryTest.scala
@@ -3,15 +3,20 @@ package cromwell.pipeline.datastorage.dao.repository
 import com.dimafeng.testcontainers.{ ForAllTestContainer, PostgreSQLContainer }
 import com.typesafe.config.Config
 import cromwell.pipeline.datastorage.DatastorageModule
-import cromwell.pipeline.datastorage.dao.utils.{ TestProjectUtils, TestRunUtils, TestUserUtils }
+import cromwell.pipeline.datastorage.dao.utils.{ PostgreTablesCleaner, TestProjectUtils, TestRunUtils, TestUserUtils }
 import cromwell.pipeline.datastorage.dto.{ Done, Project, Run, User }
 import cromwell.pipeline.utils.{ ApplicationConfig, TestContainersUtils }
 import org.scalatest.{ AsyncWordSpec, BeforeAndAfterAll, Matchers }
 
-class RunRepositoryTest extends AsyncWordSpec with Matchers with BeforeAndAfterAll with ForAllTestContainer {
+class RunRepositoryTest
+    extends AsyncWordSpec
+    with Matchers
+    with BeforeAndAfterAll
+    with ForAllTestContainer
+    with PostgreTablesCleaner {
 
-  private lazy val config: Config = TestContainersUtils.getConfigForPgContainer(container)
-  private lazy val datastorageModule: DatastorageModule = new DatastorageModule(ApplicationConfig.load(config))
+  protected lazy val config: Config = TestContainersUtils.getConfigForPgContainer(container)
+  protected lazy val datastorageModule: DatastorageModule = new DatastorageModule(ApplicationConfig.load(config))
   override val container: PostgreSQLContainer = TestContainersUtils.getPostgreSQLContainer()
 
   override protected def beforeAll(): Unit = {

--- a/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/UserRepositoryTest.scala
+++ b/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/UserRepositoryTest.scala
@@ -4,17 +4,22 @@ import cats.implicits._
 import com.dimafeng.testcontainers.{ ForAllTestContainer, PostgreSQLContainer }
 import com.typesafe.config.Config
 import cromwell.pipeline.datastorage.DatastorageModule
-import cromwell.pipeline.datastorage.dao.utils.TestUserUtils
+import cromwell.pipeline.datastorage.dao.utils.{ PostgreTablesCleaner, TestUserUtils }
 import cromwell.pipeline.model.validator.Enable
 import cromwell.pipeline.model.wrapper.{ Name, UserEmail }
 import cromwell.pipeline.utils.{ ApplicationConfig, StringUtils, TestContainersUtils }
 import org.scalatest.{ AsyncWordSpec, BeforeAndAfterAll, Matchers }
 
-class UserRepositoryTest extends AsyncWordSpec with Matchers with BeforeAndAfterAll with ForAllTestContainer {
+class UserRepositoryTest
+    extends AsyncWordSpec
+    with Matchers
+    with BeforeAndAfterAll
+    with ForAllTestContainer
+    with PostgreTablesCleaner {
 
   override val container: PostgreSQLContainer = TestContainersUtils.getPostgreSQLContainer()
-  private lazy val config: Config = TestContainersUtils.getConfigForPgContainer(container)
-  private lazy val datastorageModule: DatastorageModule = new DatastorageModule(ApplicationConfig.load(config))
+  protected lazy val config: Config = TestContainersUtils.getConfigForPgContainer(container)
+  protected lazy val datastorageModule: DatastorageModule = new DatastorageModule(ApplicationConfig.load(config))
   import datastorageModule.userRepository
 
   override protected def beforeAll(): Unit = {
@@ -66,18 +71,18 @@ class UserRepositoryTest extends AsyncWordSpec with Matchers with BeforeAndAfter
 
       "update email, firstName and lastName" taggedAs Dao in {
         val dummyUser = TestUserUtils.getDummyUser()
-        userRepository.addUser(dummyUser)
         val updatedUser =
           dummyUser.copy(
             email = UserEmail("updated@email.com", Enable.Unsafe),
             firstName = Name("updatedFName", Enable.Unsafe),
             lastName = Name("updatedLName", Enable.Unsafe)
           )
-        userRepository
-          .updateUser(updatedUser)
-          .flatMap(
-            _ => userRepository.getUserById(dummyUser.userId).map(dummyUser => dummyUser.get shouldEqual updatedUser)
-          )
+        val result = for {
+          _ <- userRepository.addUser(dummyUser)
+          _ <- userRepository.updateUser(updatedUser)
+          updatedDataUser <- userRepository.getUserById(dummyUser.userId)
+        } yield updatedDataUser
+        result.map(updatedDataUser => updatedDataUser.get shouldEqual updatedUser)
       }
     }
 
@@ -85,13 +90,13 @@ class UserRepositoryTest extends AsyncWordSpec with Matchers with BeforeAndAfter
 
       "update password" taggedAs Dao in {
         val dummyUser = TestUserUtils.getDummyUser()
-        userRepository.addUser(dummyUser)
         val updatedUser = dummyUser.copy(passwordHash = newPasswordHash)
-        userRepository
-          .updatePassword(updatedUser)
-          .flatMap(
-            _ => userRepository.getUserById(dummyUser.userId).map(dummyUser => dummyUser.get shouldEqual updatedUser)
-          )
+        val result = for {
+          _ <- userRepository.addUser(dummyUser)
+          _ <- userRepository.updatePassword(updatedUser)
+          userWithNewPassword <- userRepository.getUserById(dummyUser.userId)
+        } yield userWithNewPassword
+        result.map(userWithNewPassword => userWithNewPassword.get shouldEqual updatedUser)
       }
     }
   }

--- a/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/utils/PostgreTablesCleaner.scala
+++ b/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/utils/PostgreTablesCleaner.scala
@@ -1,0 +1,36 @@
+package cromwell.pipeline.datastorage.dao.utils
+
+import com.typesafe.config.Config
+import cromwell.pipeline.database.LiquibaseUtils
+import cromwell.pipeline.datastorage.DatastorageModule
+import cromwell.pipeline.utils.TestTimeout
+import org.scalatest.{ BeforeAndAfterEach, Suite }
+import slick.jdbc.JdbcProfile
+
+import scala.concurrent.Await
+
+trait PostgreTablesCleaner extends BeforeAndAfterEach with TestTimeout {
+
+  this: Suite =>
+
+  protected def config: Config
+  protected def datastorageModule: DatastorageModule
+  protected def changeLogCleanTablesResourcePath: String =
+    config.getString("database.liquibase.changeLogCleanTablesResourcePath")
+
+  private lazy val profile = datastorageModule.pipelineDatabaseEngine.profile
+  private lazy val database = datastorageModule.pipelineDatabaseEngine.database
+
+  def cleanTables(profile: JdbcProfile, database: JdbcProfile#Backend#Database): Unit = {
+    val action = profile.api.SimpleDBIO(
+      context => LiquibaseUtils.updateSchema(changeLogCleanTablesResourcePath)(context.connection)
+    )
+    Await.result(database.run(action), timeoutAsDuration)
+  }
+
+  override protected def afterEach(): Unit = {
+    super.afterEach()
+    cleanTables(profile, database)
+  }
+
+}


### PR DESCRIPTION
Repository tests (`ProjectRepositoryTest`, `RunRepositoryTest`, `UserRepositoryTest`) may randomly fail because of unique constraint in database.

- Added functionality to clean tables after every testcase in Repository tests to avoid possible db ID collisions.
- PostgreTestSources created
 