### PR TITLE
EPMLSTRCMW-251 Feat: Generate exception in LiquidBaseUtils

### DIFF
--- a/controllers/src/main/scala/cromwell/pipeline/controller/ProjectController.scala
+++ b/controllers/src/main/scala/cromwell/pipeline/controller/ProjectController.scala
@@ -5,7 +5,7 @@ import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import cromwell.pipeline.datastorage.dto.auth.AccessTokenContent
 import cromwell.pipeline.datastorage.dto.{ ProjectAdditionRequest, ProjectDeleteRequest, ProjectUpdateNameRequest }
-import cromwell.pipeline.service.Exceptions.{ ProjectAccessDeniedException, ProjectNotFoundException }
+import cromwell.pipeline.service.ProjectService.Exceptions.{ ProjectAccessDeniedException, ProjectNotFoundException }
 import cromwell.pipeline.service.{ ProjectService, VersioningException }
 import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
 

--- a/datasource/src/main/scala/cromwell/pipeline/database/LiquibaseExceptions.scala
+++ b/datasource/src/main/scala/cromwell/pipeline/database/LiquibaseExceptions.scala
@@ -1,0 +1,8 @@
+package cromwell.pipeline.database
+
+object LiquibaseExceptions {
+  final case class LiquibaseUpdateSchemaException(
+    cause: Throwable,
+    message: String = "An error during the schema update via liquibase."
+  ) extends RuntimeException(message, cause)
+}

--- a/datasource/src/main/scala/cromwell/pipeline/database/PipelineDatabaseEngine.scala
+++ b/datasource/src/main/scala/cromwell/pipeline/database/PipelineDatabaseEngine.scala
@@ -1,13 +1,13 @@
 package cromwell.pipeline.database
 
-import java.sql.Connection
-
 import com.typesafe.config.{ Config, ConfigFactory }
 import slick.basic.DatabaseConfig
 import slick.jdbc.JdbcProfile
 
+import java.sql.Connection
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
+import scala.util.Try
 
 class PipelineDatabaseEngine(config: Config = ConfigFactory.load()) extends AutoCloseable {
 
@@ -19,7 +19,7 @@ class PipelineDatabaseEngine(config: Config = ConfigFactory.load()) extends Auto
 
   import profile.api._
 
-  def updateSchema(): Unit =
+  def updateSchema(): Try[Unit] =
     withConnection(LiquibaseUtils.updateSchema(changeLogResourcePath))
 
   private def withConnection[A](actionFunc: Connection => A): A = {

--- a/services/src/main/scala/cromwell/pipeline/service/ProjectService.scala
+++ b/services/src/main/scala/cromwell/pipeline/service/ProjectService.scala
@@ -3,7 +3,7 @@ package cromwell.pipeline.service
 import cromwell.pipeline.datastorage.dao.repository.ProjectRepository
 import cromwell.pipeline.datastorage.dto._
 import cromwell.pipeline.model.wrapper.UserId
-import cromwell.pipeline.service.Exceptions.{ ProjectAccessDeniedException, ProjectNotFoundException }
+import cromwell.pipeline.service.ProjectService.Exceptions.{ ProjectAccessDeniedException, ProjectNotFoundException }
 
 import java.util.UUID
 import scala.concurrent.{ ExecutionContext, Future }
@@ -61,8 +61,10 @@ class ProjectService(projectRepository: ProjectRepository, projectVersioning: Pr
     }
 }
 
-object Exceptions {
-  final case class ProjectNotFoundException(message: String = "Project not found") extends RuntimeException(message)
-  final case class ProjectAccessDeniedException(message: String = "Access denied. You  not owner of the project")
-      extends RuntimeException(message)
+object ProjectService {
+  object Exceptions {
+    final case class ProjectNotFoundException(message: String = "Project not found") extends RuntimeException(message)
+    final case class ProjectAccessDeniedException(message: String = "Access denied. You  not owner of the project")
+        extends RuntimeException(message)
+  }
 }

--- a/services/src/test/scala/cromwell/pipeline/service/AggregationServiceTest.scala
+++ b/services/src/test/scala/cromwell/pipeline/service/AggregationServiceTest.scala
@@ -1,21 +1,8 @@
 package cromwell.pipeline.service
 
 import cromwell.pipeline.datastorage.dao.utils.{ TestProjectUtils, TestRunUtils, TestUserUtils }
-import cromwell.pipeline.datastorage.dto.{
-  CromwellInput,
-  FileParameter,
-  FileTree,
-  PipelineVersion,
-  Project,
-  ProjectConfiguration,
-  ProjectConfigurationId,
-  ProjectConfigurationVersion,
-  ProjectFile,
-  ProjectFileConfiguration,
-  ProjectFileContent,
-  StringTyped
-}
-import cromwell.pipeline.service.Exceptions.ProjectNotFoundException
+import cromwell.pipeline.datastorage.dto._
+import cromwell.pipeline.service.ProjectService.Exceptions.ProjectNotFoundException
 import org.mockito.Mockito.when
 import org.scalatest.{ AsyncWordSpec, Matchers }
 import org.scalatestplus.mockito.MockitoSugar

--- a/services/src/test/scala/cromwell/pipeline/service/ProjectConfigurationServiceTest.scala
+++ b/services/src/test/scala/cromwell/pipeline/service/ProjectConfigurationServiceTest.scala
@@ -1,15 +1,15 @@
 package cromwell.pipeline.service
 
-import java.nio.file.Paths
 import cromwell.pipeline.datastorage.dao.repository.ProjectConfigurationRepository
 import cromwell.pipeline.datastorage.dao.utils.{ TestProjectUtils, TestUserUtils }
 import cromwell.pipeline.datastorage.dto._
 import cromwell.pipeline.model.wrapper.UserId
-import cromwell.pipeline.service.Exceptions.ProjectAccessDeniedException
+import cromwell.pipeline.service.ProjectService.Exceptions.ProjectAccessDeniedException
 import org.mockito.Mockito.when
 import org.scalatest.{ AsyncWordSpec, Matchers }
 import org.scalatestplus.mockito.MockitoSugar
 
+import java.nio.file.Paths
 import scala.concurrent.Future
 
 class ProjectConfigurationServiceTest extends AsyncWordSpec with Matchers with MockitoSugar {

--- a/services/src/test/scala/cromwell/pipeline/service/ProjectServiceTest.scala
+++ b/services/src/test/scala/cromwell/pipeline/service/ProjectServiceTest.scala
@@ -4,7 +4,7 @@ import cromwell.pipeline.datastorage.dao.repository.ProjectRepository
 import cromwell.pipeline.datastorage.dao.utils.TestProjectUtils
 import cromwell.pipeline.datastorage.dto._
 import cromwell.pipeline.model.wrapper.UserId
-import cromwell.pipeline.service.Exceptions.{ ProjectAccessDeniedException, ProjectNotFoundException }
+import cromwell.pipeline.service.ProjectService.Exceptions.{ ProjectAccessDeniedException, ProjectNotFoundException }
 import org.mockito.Matchers.any
 import org.mockito.Mockito.when
 import org.scalatest.{ AsyncWordSpec, Matchers }


### PR DESCRIPTION
DESCRIPTION

In the liquibase utils in case of error we're just logging message. There is no good in this. Please make it return the error, and pass this error right to the Main class. Also consider failing pipeline start if migration is failed.

CHANGES

- LiquibaseUtils.scala, PipelineDatebaseEngine.scala and CromwellPipelineApp.scala have been updated
-  Now updateSchema method may return a liquibaseUpdateSchemaException which may be thown to main class and the application stops as a result.
