### PR TITLE
EPMLSTRCMW-240 Refactor: Split repository classes into traits

### DIFF
--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/DatastorageModule.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/DatastorageModule.scala
@@ -15,7 +15,7 @@ import cromwell.pipeline.model.wrapper.{ Name, RunId, UserEmail, UserId }
 import cromwell.pipeline.utils.ApplicationConfig
 import org.mongodb.scala.{ Document, MongoCollection }
 import slick.jdbc.JdbcProfile
-import slick.lifted.StringColumnExtensionMethods
+import slick.lifted.{ Isomorphism, Rep, StringColumnExtensionMethods }
 
 import scala.concurrent.ExecutionContext
 
@@ -29,21 +29,18 @@ class DatastorageModule(applicationConfig: ApplicationConfig)(implicit execution
   lazy val documentRepository: DocumentRepository = new DocumentRepository(mongoCollection)
 
   lazy val userRepository: UserRepository =
-    new UserRepository(pipelineDatabaseEngine, databaseLayer)
+    UserRepository(pipelineDatabaseEngine, databaseLayer)
   lazy val projectRepository: ProjectRepository =
-    new ProjectRepository(pipelineDatabaseEngine, databaseLayer)
+    ProjectRepository(pipelineDatabaseEngine, databaseLayer)
   lazy val runRepository: RunRepository =
-    new RunRepository(pipelineDatabaseEngine, databaseLayer)
+    RunRepository(pipelineDatabaseEngine, databaseLayer)
   lazy val configurationRepository: ProjectConfigurationRepository =
-    new ProjectConfigurationRepository(documentRepository)
+    ProjectConfigurationRepository(documentRepository)
 }
 
 trait Profile {
   val profile: JdbcProfile
   object Implicits {
-
-    import cats.implicits.catsStdShowForString
-    import profile.api._
 
     import scala.language.implicitConversions
 

--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/dao/repository/ProjectConfigurationRepository.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/dao/repository/ProjectConfigurationRepository.scala
@@ -6,20 +6,38 @@ import cromwell.pipeline.datastorage.dto.{ ProjectConfiguration, ProjectConfigur
 
 import scala.concurrent.{ ExecutionContext, Future }
 
-class ProjectConfigurationRepository(repository: DocumentRepository)(implicit ec: ExecutionContext) {
+trait ProjectConfigurationRepository {
 
-  private def upsertConfiguration(projectConfiguration: ProjectConfiguration): Future[Unit] =
-    repository.upsertOne(projectConfiguration, "id", projectConfiguration.id.value)
+  def addConfiguration(projectConfiguration: ProjectConfiguration): Future[Unit]
 
-  def addConfiguration(projectConfiguration: ProjectConfiguration): Future[Unit] =
-    upsertConfiguration(projectConfiguration)
+  def updateConfiguration(projectConfiguration: ProjectConfiguration): Future[Unit]
 
-  def updateConfiguration(projectConfiguration: ProjectConfiguration): Future[Unit] =
-    upsertConfiguration(projectConfiguration)
+  def getById(id: ProjectConfigurationId): Future[Option[ProjectConfiguration]]
 
-  def getById(id: ProjectConfigurationId): Future[Option[ProjectConfiguration]] =
-    repository.getByParam("id", id.value).map(_.headOption)
+  def getAllByProjectId(projectId: ProjectId): Future[Seq[ProjectConfiguration]]
 
-  def getAllByProjectId(projectId: ProjectId): Future[Seq[ProjectConfiguration]] =
-    repository.getByParam("projectId", projectId.value)
+}
+
+object ProjectConfigurationRepository {
+
+  def apply(repository: DocumentRepository)(implicit ec: ExecutionContext): ProjectConfigurationRepository =
+    new ProjectConfigurationRepository {
+
+      private def upsertConfiguration(projectConfiguration: ProjectConfiguration): Future[Unit] =
+        repository.upsertOne(projectConfiguration, "id", projectConfiguration.id.value)
+
+      def addConfiguration(projectConfiguration: ProjectConfiguration): Future[Unit] =
+        upsertConfiguration(projectConfiguration)
+
+      def updateConfiguration(projectConfiguration: ProjectConfiguration): Future[Unit] =
+        upsertConfiguration(projectConfiguration)
+
+      def getById(id: ProjectConfigurationId): Future[Option[ProjectConfiguration]] =
+        repository.getByParam("id", id.value).map(_.headOption)
+
+      def getAllByProjectId(projectId: ProjectId): Future[Seq[ProjectConfiguration]] =
+        repository.getByParam("projectId", projectId.value)
+
+    }
+
 }

--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/dao/repository/ProjectRepository.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/dao/repository/ProjectRepository.scala
@@ -6,25 +6,48 @@ import cromwell.pipeline.datastorage.dto.{ Project, ProjectId }
 
 import scala.concurrent.Future
 
-class ProjectRepository(pipelineDatabaseEngine: PipelineDatabaseEngine, projectEntry: ProjectEntry) {
+trait ProjectRepository {
 
-  import pipelineDatabaseEngine._
-  import pipelineDatabaseEngine.profile.api._
+  def getProjectById(projectId: ProjectId): Future[Option[Project]]
 
-  def getProjectById(projectId: ProjectId): Future[Option[Project]] =
-    database.run(projectEntry.getProjectByIdAction(projectId).result.headOption)
+  def getProjectsByName(name: String): Future[Seq[Project]]
 
-  def getProjectsByName(name: String): Future[Seq[Project]] =
-    database.run(projectEntry.getProjectsByNameAction(name).result)
+  def addProject(project: Project): Future[ProjectId]
 
-  def addProject(project: Project): Future[ProjectId] = database.run(projectEntry.addProjectAction(project))
+  def deactivateProjectById(projectId: ProjectId): Future[Int]
 
-  def deactivateProjectById(projectId: ProjectId): Future[Int] =
-    database.run(projectEntry.deactivateProjectByIdAction(projectId))
+  def updateProjectName(updatedProject: Project): Future[Int]
 
-  def updateProjectName(updatedProject: Project): Future[Int] =
-    database.run(projectEntry.updateProjectNameAction(updatedProject))
+  def updateProjectVersion(updatedProject: Project): Future[Int]
 
-  def updateProjectVersion(updatedProject: Project): Future[Int] =
-    database.run(projectEntry.updateProjectVersionAction(updatedProject))
+}
+
+object ProjectRepository {
+
+  def apply(pipelineDatabaseEngine: PipelineDatabaseEngine, projectEntry: ProjectEntry): ProjectRepository =
+    new ProjectRepository {
+
+      import pipelineDatabaseEngine._
+
+      import pipelineDatabaseEngine.profile.api._
+
+      def getProjectById(projectId: ProjectId): Future[Option[Project]] =
+        database.run(projectEntry.getProjectByIdAction(projectId).result.headOption)
+
+      def getProjectsByName(name: String): Future[Seq[Project]] =
+        database.run(projectEntry.getProjectsByNameAction(name).result)
+
+      def addProject(project: Project): Future[ProjectId] = database.run(projectEntry.addProjectAction(project))
+
+      def deactivateProjectById(projectId: ProjectId): Future[Int] =
+        database.run(projectEntry.deactivateProjectByIdAction(projectId))
+
+      def updateProjectName(updatedProject: Project): Future[Int] =
+        database.run(projectEntry.updateProjectNameAction(updatedProject))
+
+      def updateProjectVersion(updatedProject: Project): Future[Int] =
+        database.run(projectEntry.updateProjectVersionAction(updatedProject))
+
+    }
+
 }

--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/dao/repository/RunRepository.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/dao/repository/RunRepository.scala
@@ -7,17 +7,36 @@ import cromwell.pipeline.model.wrapper.{ RunId, UserId }
 
 import scala.concurrent.Future
 
-class RunRepository(pipelineDatabaseEngine: PipelineDatabaseEngine, runEntry: RunEntry) {
+trait RunRepository {
 
-  import pipelineDatabaseEngine._
-  import pipelineDatabaseEngine.profile.api._
+  def getRunByIdAndUser(runId: RunId, userId: UserId): Future[Option[Run]]
 
-  def getRunByIdAndUser(runId: RunId, userId: UserId): Future[Option[Run]] =
-    database.run(runEntry.getRunByIdAndUser(runId, userId).result.headOption)
+  def deleteRunById(runId: RunId): Future[Int]
 
-  def deleteRunById(runId: RunId): Future[Int] = database.run(runEntry.deleteRunById(runId))
+  def addRun(run: Run): Future[RunId]
 
-  def addRun(run: Run): Future[RunId] = database.run(runEntry.addRun(run))
+  def updateRun(updatedRun: Run): Future[Int]
 
-  def updateRun(updatedRun: Run): Future[Int] = database.run(runEntry.updateRun(updatedRun))
+}
+
+object RunRepository {
+
+  def apply(pipelineDatabaseEngine: PipelineDatabaseEngine, runEntry: RunEntry): RunRepository =
+    new RunRepository {
+
+      import pipelineDatabaseEngine._
+
+      import pipelineDatabaseEngine.profile.api._
+
+      def getRunByIdAndUser(runId: RunId, userId: UserId): Future[Option[Run]] =
+        database.run(runEntry.getRunByIdAndUser(runId, userId).result.headOption)
+
+      def deleteRunById(runId: RunId): Future[Int] = database.run(runEntry.deleteRunById(runId))
+
+      def addRun(run: Run): Future[RunId] = database.run(runEntry.addRun(run))
+
+      def updateRun(updatedRun: Run): Future[Int] = database.run(runEntry.updateRun(updatedRun))
+
+    }
+
 }

--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/dao/repository/UserRepository.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/dao/repository/UserRepository.scala
@@ -7,27 +7,52 @@ import cromwell.pipeline.model.wrapper.{ UserEmail, UserId }
 
 import scala.concurrent.Future
 
-class UserRepository(pipelineDatabaseEngine: PipelineDatabaseEngine, userEntry: UserEntry) {
+trait UserRepository {
 
-  import pipelineDatabaseEngine._
-  import pipelineDatabaseEngine.profile.api._
+  def getUserById(userId: UserId): Future[Option[User]]
 
-  def getUserById(userId: UserId): Future[Option[User]] =
-    database.run(userEntry.getUserByIdAction(userId).result.headOption)
+  def getUserByEmail(email: UserEmail): Future[Option[User]]
 
-  def getUserByEmail(email: UserEmail): Future[Option[User]] =
-    database.run(userEntry.getUserByEmailAction(email).result.headOption)
+  def getUsersByEmail(emailPattern: String): Future[Seq[User]]
 
-  def getUsersByEmail(emailPattern: String): Future[Seq[User]] =
-    database.run(userEntry.getUsersByEmailAction(emailPattern))
+  def addUser(user: User): Future[UserId]
 
-  def addUser(user: User): Future[UserId] = database.run(userEntry.addUserAction(user))
+  def deactivateUserByEmail(email: UserEmail): Future[Int]
 
-  def deactivateUserByEmail(email: UserEmail): Future[Int] = database.run(userEntry.deactivateUserByEmail(email))
+  def deactivateUserById(userId: UserId): Future[Int]
 
-  def deactivateUserById(userId: UserId): Future[Int] = database.run(userEntry.deactivateUserById(userId))
+  def updateUser(updatedUser: User): Future[Int]
 
-  def updateUser(updatedUser: User): Future[Int] = database.run(userEntry.updateUser(updatedUser))
+  def updatePassword(updatedUser: User): Future[Int]
 
-  def updatePassword(updatedUser: User): Future[Int] = database.run(userEntry.updatePassword(updatedUser))
+}
+
+object UserRepository {
+  def apply(pipelineDatabaseEngine: PipelineDatabaseEngine, userEntry: UserEntry): UserRepository =
+    new UserRepository {
+
+      import pipelineDatabaseEngine._
+      import pipelineDatabaseEngine.profile.api._
+
+      def getUserById(userId: UserId): Future[Option[User]] =
+        database.run(userEntry.getUserByIdAction(userId).result.headOption)
+
+      def getUserByEmail(email: UserEmail): Future[Option[User]] =
+        database.run(userEntry.getUserByEmailAction(email).result.headOption)
+
+      def getUsersByEmail(emailPattern: String): Future[Seq[User]] =
+        database.run(userEntry.getUsersByEmailAction(emailPattern))
+
+      def addUser(user: User): Future[UserId] = database.run(userEntry.addUserAction(user))
+
+      def deactivateUserByEmail(email: UserEmail): Future[Int] = database.run(userEntry.deactivateUserByEmail(email))
+
+      def deactivateUserById(userId: UserId): Future[Int] = database.run(userEntry.deactivateUserById(userId))
+
+      def updateUser(updatedUser: User): Future[Int] = database.run(userEntry.updateUser(updatedUser))
+
+      def updatePassword(updatedUser: User): Future[Int] = database.run(userEntry.updatePassword(updatedUser))
+
+    }
+
 }

--- a/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/ProjectConfigurationRepositoryTest.scala
+++ b/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/ProjectConfigurationRepositoryTest.scala
@@ -15,7 +15,7 @@ import scala.concurrent.Future
 class ProjectConfigurationRepositoryTest extends AsyncWordSpec with Matchers with MockitoSugar {
 
   private val documentRepository = mock[DocumentRepository]
-  private val configurationRepository = new ProjectConfigurationRepository(documentRepository)
+  private val configurationRepository = ProjectConfigurationRepository(documentRepository)
   private val projectFileConfiguration: ProjectFileConfiguration =
     ProjectFileConfiguration(Paths.get("/home/file"), List(FileParameter("nodeName", StringTyped(Some("hello")))))
   private val projectId: ProjectId = TestProjectUtils.getDummyProjectId


### PR DESCRIPTION
**DESCRIPTION**

For each existing repository which we have we should create trait and companion object with the implementation.

**CHANGES**

- DatastorageModule.scala, ProjectConfigurationRepository.scala, ProjectRepository.scala, RunRepository.scala, UserRepository.scala and ProjectConfigurationRepositoryTest.scala have been updated
- It allows to create instances by apply() method 