### PR TITLE
EPMLSTRCMW-242 refactor: Add test implementation of repository classes

### DIFF
--- a/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/ProjectConfigurationRepositoryTestImpl.scala
+++ b/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/ProjectConfigurationRepositoryTestImpl.scala
@@ -1,0 +1,39 @@
+package cromwell.pipeline.datastorage.dao.repository
+
+import cromwell.pipeline.datastorage.dto.{ ProjectConfiguration, ProjectConfigurationId, ProjectId }
+import scala.collection.mutable
+import scala.concurrent.Future
+
+class ProjectConfigurationRepositoryTestImpl extends ProjectConfigurationRepository {
+
+  private val configurations: mutable.Map[ProjectConfigurationId, ProjectConfiguration] = mutable.Map.empty
+
+  def addConfiguration(projectConfiguration: ProjectConfiguration): Future[Unit] = {
+    configurations += (projectConfiguration.id -> projectConfiguration)
+    Future.unit
+  }
+
+  def updateConfiguration(projectConfiguration: ProjectConfiguration): Future[Unit] = {
+    if (configurations.contains(projectConfiguration.id)) {
+      configurations += (projectConfiguration.id -> projectConfiguration)
+    }
+    Future.unit
+  }
+
+  def getById(id: ProjectConfigurationId): Future[Option[ProjectConfiguration]] =
+    Future.successful(configurations.get(id))
+
+  def getAllByProjectId(projectId: ProjectId): Future[Seq[ProjectConfiguration]] =
+    Future.successful(configurations.values.filter(_.projectId == projectId).toSeq)
+
+}
+
+object ProjectConfigurationRepositoryTestImpl {
+
+  def apply(configurations: ProjectConfiguration*): ProjectConfigurationRepositoryTestImpl = {
+    val projectConfigurationRepositoryTestImpl = new ProjectConfigurationRepositoryTestImpl
+    configurations.foreach(projectConfigurationRepositoryTestImpl.addConfiguration)
+    projectConfigurationRepositoryTestImpl
+  }
+
+}

--- a/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/ProjectRepositoryTestImpl.scala
+++ b/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/ProjectRepositoryTestImpl.scala
@@ -1,0 +1,50 @@
+package cromwell.pipeline.datastorage.dao.repository
+
+import cromwell.pipeline.datastorage.dto.{ Project, ProjectId }
+import scala.collection.mutable
+import scala.concurrent.Future
+
+class ProjectRepositoryTestImpl extends ProjectRepository {
+
+  private val projects: mutable.Map[ProjectId, Project] = mutable.Map.empty
+
+  def getProjectById(projectId: ProjectId): Future[Option[Project]] =
+    Future.successful(projects.get(projectId))
+
+  def getProjectsByName(name: String): Future[Seq[Project]] =
+    Future.successful(projects.values.filter(_.name == name).toSeq)
+
+  def addProject(project: Project): Future[ProjectId] = {
+    projects += (project.projectId -> project)
+    Future.successful(project.projectId)
+  }
+
+  def deactivateProjectById(projectId: ProjectId): Future[Int] = {
+    for {
+      (id, project) <- projects if id == projectId
+      deactivatedProject = project.copy(active = false)
+    } yield projects += (deactivatedProject.projectId -> deactivatedProject)
+
+    Future.successful(0)
+  }
+
+  def updateProjectName(updatedProject: Project): Future[Int] = updateProject(updatedProject)
+
+  def updateProjectVersion(updatedProject: Project): Future[Int] = updateProject(updatedProject)
+
+  private def updateProject(updatedProject: Project): Future[Int] = {
+    if (projects.contains(updatedProject.projectId)) projects += (updatedProject.projectId -> updatedProject)
+    Future.successful(0)
+  }
+
+}
+
+object ProjectRepositoryTestImpl {
+
+  def apply(projects: Project*): ProjectRepositoryTestImpl = {
+    val projectRepositoryTestImpl = new ProjectRepositoryTestImpl
+    projects.foreach(projectRepositoryTestImpl.addProject)
+    projectRepositoryTestImpl
+  }
+
+}

--- a/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/RunRepositoryTestImpl.scala
+++ b/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/RunRepositoryTestImpl.scala
@@ -1,0 +1,44 @@
+package cromwell.pipeline.datastorage.dao.repository
+
+import cromwell.pipeline.datastorage.dto.Run
+import cromwell.pipeline.model.wrapper.{ RunId, UserId }
+import scala.collection.mutable
+import scala.concurrent.Future
+
+class RunRepositoryTestImpl extends RunRepository {
+
+  private val runs: mutable.Map[RunId, Run] = mutable.Map.empty
+
+  def getRunByIdAndUser(runId: RunId, userId: UserId): Future[Option[Run]] = {
+    val run = for {
+      (id, entity) <- runs if id == runId && entity.userId == userId
+    } yield entity
+    Future.successful(run.headOption)
+  }
+
+  def deleteRunById(runId: RunId): Future[Int] = {
+    runs -= runId
+    Future.successful(0)
+  }
+
+  def addRun(run: Run): Future[RunId] = {
+    runs += (run.runId -> run)
+    Future.successful(run.runId)
+  }
+
+  def updateRun(updatedRun: Run): Future[Int] = {
+    if (runs.contains(updatedRun.runId)) runs += (updatedRun.runId -> updatedRun)
+    Future.successful(0)
+  }
+
+}
+
+object RunRepositoryTestImpl {
+
+  def apply(runs: Run*): RunRepositoryTestImpl = {
+    val runRepositoryTestImpl = new RunRepositoryTestImpl
+    runs.foreach(runRepositoryTestImpl.addRun)
+    runRepositoryTestImpl
+  }
+
+}

--- a/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/UserRepositoryTestImp.scala
+++ b/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/UserRepositoryTestImp.scala
@@ -1,0 +1,59 @@
+package cromwell.pipeline.datastorage.dao.repository
+
+import cromwell.pipeline.datastorage.dto.User
+import cromwell.pipeline.model.wrapper.{ UserEmail, UserId }
+import scala.collection.mutable
+import scala.concurrent.Future
+
+class UserRepositoryTestImp extends UserRepository {
+
+  private val users: mutable.Map[UserId, User] = mutable.Map.empty
+
+  def getUserById(userId: UserId): Future[Option[User]] =
+    Future.successful(users.get(userId))
+
+  def getUserByEmail(email: UserEmail): Future[Option[User]] =
+    Future.successful(users.values.find(_.email == email))
+
+  def getUsersByEmail(emailPattern: String): Future[Seq[User]] =
+    Future.successful(users.values.filter(_.email.unwrap.contains(emailPattern)).toSeq)
+
+  def addUser(user: User): Future[UserId] = {
+    users += (user.userId -> user)
+    Future.successful(user.userId)
+  }
+
+  def deactivateUserByEmail(email: UserEmail): Future[Int] =
+    deactivateUser[UserEmail](email, user => user.email)
+
+  def deactivateUserById(userId: UserId): Future[Int] =
+    deactivateUser[UserId](userId, user => user.userId)
+
+  private def deactivateUser[A](userParam: A, toUserField: User => A): Future[Int] = {
+    for {
+      (_, user) <- users if userParam == toUserField(user)
+      deactivatedUser = user.copy(active = false)
+    } yield users += (deactivatedUser.userId -> deactivatedUser)
+    Future.successful(0)
+  }
+
+  def updateUser(updatedUser: User): Future[Int] = update(updatedUser)
+
+  def updatePassword(updatedUser: User): Future[Int] = update(updatedUser)
+
+  private def update(updatedUser: User): Future[Int] = {
+    if (users.contains(updatedUser.userId)) users += (updatedUser.userId -> updatedUser)
+    Future.successful(0)
+  }
+
+}
+
+object UserRepositoryTestImp {
+
+  def apply(users: User*): UserRepositoryTestImp = {
+    val userRepositoryTestImp = new UserRepositoryTestImp
+    users.foreach(userRepositoryTestImp.addUser)
+    userRepositoryTestImp
+  }
+
+}


### PR DESCRIPTION
**DESCRIPTION**

Test implementation of repository classes most likely should use in-memory data structures like `Map`s to persist their state.
They should provide some util methods to make creation easier.

**CHANGES**

- ProjectConfigurationRepositoryTestImpl.scala, ProjectRepositoryTestImpl.scala, RunRepositoryTestImpl.scala and UserRepositoryTestImp.scala have been added
- It allows you to avoid using mocks and makes testing easier.