### PR TITLE
EPMLSTRCMW-254 Feat: Add getFiles in ProjectFileController

### DIFF
--- a/controllers/src/main/scala/cromwell/pipeline/controller/utils/PathMatchers.scala
+++ b/controllers/src/main/scala/cromwell/pipeline/controller/utils/PathMatchers.scala
@@ -1,0 +1,12 @@
+package cromwell.pipeline.controller.utils
+
+import akka.http.scaladsl.server.PathMatcher1
+import akka.http.scaladsl.server.PathMatchers.Segment
+import cromwell.pipeline.datastorage.dto
+
+import java.nio.file.{ Path, Paths }
+
+object PathMatchers {
+  val ProjectId: PathMatcher1[dto.ProjectId] = Segment.map(dto.ProjectId(_))
+  val Path: PathMatcher1[Path] = Segment.map(Paths.get(_))
+}

--- a/postman/Files.postman_collection.json
+++ b/postman/Files.postman_collection.json
@@ -6,6 +6,74 @@
 	},
 	"item": [
 		{
+			"name": "Get project files by projectId",
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "{{auth_token}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{base_url}}/files/{{project_id}}?version=v0.0.1",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"files",
+						"{{project_id}}"
+					],
+					"query": [
+						{
+							"key": "version",
+							"value": "v0.0.1"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get project file by projectId and Path",
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "{{auth_token}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{base_url}}/files/{{project_id}}/{{project_file_path}}?version=v0.0.1",
+					"host": [
+						"{{base_url}}"
+					],
+					"path": [
+						"files",
+						"{{project_id}}",
+						"{{project_file_path}}"
+					],
+					"query": [
+						{
+							"key": "version",
+							"value": "v0.0.1"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
 			"name": "Validate WDL file",
 			"request": {
 				"method": "POST",
@@ -82,26 +150,20 @@
 					}
 				],
 				"url": {
-					"raw": "{{base_url}}/files/configurations?project_id=project_id&project_file_path=path&version=version",
+					"raw": "{{base_url}}/files/configurations/{{project_id}}/{{project_file_path}}?version=v0.0.1",
 					"host": [
 						"{{base_url}}"
 					],
 					"path": [
 						"files",
-						"configurations"
+						"configurations",
+						"{{project_id}}",
+						"{{project_file_path}}"
 					],
 					"query": [
 						{
-							"key": "project_id",
-							"value": "project_id"
-						},
-						{
-							"key": "project_file_path",
-							"value": "path"
-						},
-						{
 							"key": "version",
-							"value": "version"
+							"value": "v0.0.1"
 						}
 					]
 				}

--- a/services/src/main/scala/cromwell/pipeline/service/AggregationService.scala
+++ b/services/src/main/scala/cromwell/pipeline/service/AggregationService.scala
@@ -4,8 +4,6 @@ import cats.data.EitherT
 import cats.implicits._
 import cromwell.pipeline.datastorage.dto._
 import cromwell.pipeline.model.wrapper.UserId
-
-import java.nio.file.{ Path, Paths }
 import scala.concurrent.{ ExecutionContext, Future }
 
 trait AggregationService {
@@ -43,24 +41,11 @@ object AggregationService {
         projectId: ProjectId,
         userId: UserId,
         version: Option[PipelineVersion]
-      ): EitherT[Future, VersioningException, List[ProjectFile]] = {
-
-        type EitherF[T] = EitherT[Future, VersioningException, T]
-
-        def getProjectFile(
-          project: Project,
-          path: Path,
-          version: Option[PipelineVersion]
-        ): EitherF[ProjectFile] =
-          EitherT(projectVersioning.getFile(project, path, version))
-
+      ): EitherT[Future, VersioningException, List[ProjectFile]] =
         for {
           project <- EitherT.right(projectService.getUserProjectById(projectId, userId))
-          trees <- EitherT(projectVersioning.getFilesTree(project, version))
-          files <- trees.toList.traverse(tree => getProjectFile(project, Paths.get(tree.path), version))
+          files <- EitherT(projectVersioning.getFiles(project, version))
         } yield files
-      }
-
     }
 
 }

--- a/services/src/main/scala/cromwell/pipeline/service/ProjectVersioning.scala
+++ b/services/src/main/scala/cromwell/pipeline/service/ProjectVersioning.scala
@@ -1,9 +1,7 @@
 package cromwell.pipeline.service
 
-import java.nio.file.Path
-
 import cromwell.pipeline.datastorage.dto._
-
+import java.nio.file.Path
 import scala.concurrent.{ ExecutionContext, Future }
 
 trait ProjectVersioning[E >: VersioningException] {
@@ -22,9 +20,9 @@ trait ProjectVersioning[E >: VersioningException] {
     implicit ec: ExecutionContext
   ): AsyncResult[Project]
 
-  def getFiles(project: Project, path: Path)(
+  def getFiles(project: Project, version: Option[PipelineVersion] = None)(
     implicit ec: ExecutionContext
-  ): AsyncResult[List[String]]
+  ): AsyncResult[List[ProjectFile]]
 
   def getProjectVersions(project: Project)(
     implicit ec: ExecutionContext

--- a/services/src/test/scala/cromwell/pipeline/service/AggregationServiceTest.scala
+++ b/services/src/test/scala/cromwell/pipeline/service/AggregationServiceTest.scala
@@ -3,11 +3,10 @@ package cromwell.pipeline.service
 import cromwell.pipeline.datastorage.dao.utils.{ TestProjectUtils, TestRunUtils, TestUserUtils }
 import cromwell.pipeline.datastorage.dto._
 import cromwell.pipeline.service.ProjectService.Exceptions.ProjectNotFoundException
+import java.nio.file.Paths
 import org.mockito.Mockito.when
 import org.scalatest.{ AsyncWordSpec, Matchers }
 import org.scalatestplus.mockito.MockitoSugar
-
-import java.nio.file.Paths
 import scala.concurrent.Future
 
 class AggregationServiceTest extends AsyncWordSpec with Matchers with MockitoSugar {
@@ -40,7 +39,6 @@ class AggregationServiceTest extends AsyncWordSpec with Matchers with MockitoSug
         )
 
       "should return CromwellInput" taggedAs Service in {
-        val trees = Seq(FileTree("1", "test", path.toString, "created"))
         val file = ProjectFile(path, ProjectFileContent(""))
 
         val result = CromwellInput(
@@ -54,8 +52,7 @@ class AggregationServiceTest extends AsyncWordSpec with Matchers with MockitoSug
         )
 
         when(projectService.getUserProjectById(projectId, userId)).thenReturn(Future.successful(dummyProject))
-        when(projectVersioning.getFilesTree(dummyProject, Some(version))).thenReturn(Future.successful(Right(trees)))
-        when(projectVersioning.getFile(dummyProject, path, Some(version))).thenReturn(Future.successful(Right(file)))
+        when(projectVersioning.getFiles(dummyProject, Some(version))).thenReturn(Future.successful(Right(List(file))))
         when(projectConfigurationService.getLastByProjectId(projectId, userId))
           .thenReturn(Future.successful(Some(projectConfigurations)))
 
@@ -76,12 +73,10 @@ class AggregationServiceTest extends AsyncWordSpec with Matchers with MockitoSug
       }
 
       "should return exception if configuration not found" taggedAs Service in {
-        val trees = Seq(FileTree("1", "test", path.toString, "created"))
         val file = ProjectFile(path, ProjectFileContent(""))
 
         when(projectService.getUserProjectById(projectId, userId)).thenReturn(Future.successful(dummyProject))
-        when(projectVersioning.getFilesTree(dummyProject, Some(version))).thenReturn(Future.successful(Right(trees)))
-        when(projectVersioning.getFile(dummyProject, path, Some(version))).thenReturn(Future.successful(Right(file)))
+        when(projectVersioning.getFiles(dummyProject, Some(version))).thenReturn(Future.successful(Right(List(file))))
         when(projectConfigurationService.getLastByProjectId(projectId, userId)).thenReturn(Future.successful(None))
 
         aggregatorService.aggregate(run).failed.map {
@@ -91,7 +86,7 @@ class AggregationServiceTest extends AsyncWordSpec with Matchers with MockitoSug
 
       "should return exception if file not found" taggedAs Service in {
         when(projectService.getUserProjectById(projectId, userId)).thenReturn(Future.successful(dummyProject))
-        when(projectVersioning.getFilesTree(dummyProject, Some(version)))
+        when(projectVersioning.getFiles(dummyProject, Some(version)))
           .thenReturn(Future.successful(Left(VersioningException.FileException("Could not take the files tree"))))
         when(projectConfigurationService.getLastByProjectId(projectId, userId))
           .thenReturn(Future.successful(Some(projectConfigurations)))


### PR DESCRIPTION
**DESCRIPTION:**
add getFiles on ProjectFileService
change endpoint getFile to the REST-full
change endpoint buildConfiguration to the REST-full

CHANGES:
ProjectFileService - added getFiles method
ProjectFileController - added getFiles method and chanched endpoints from Queru to Segment parameters
ProjectFileService - just fixef formatting
AggregationService - getFilesByProjectId method have been rewritten
GitLabProjectVersioning - added getFiles method
ProjectVersioning - added getFiles method
ProjectFileServiceTest - added 3 tests
ProjectFileControllerTest - added 3 tests, changed 6 tests
AggregationServiceTest - several tests have been rewritten
GitLabProjectVersioningTest - added 2 tests