### PR TITLE
EPMLSTRCMW-281 Rename ProjectFileConfiguration to WdlParams

### DIFF
--- a/controllers/src/main/scala/cromwell/pipeline/controller/ProjectConfigurationController.scala
+++ b/controllers/src/main/scala/cromwell/pipeline/controller/ProjectConfigurationController.scala
@@ -23,7 +23,7 @@ class ProjectConfigurationController(projectConfigurationService: ProjectConfigu
         id = request.id,
         projectId = projectId,
         active = request.active,
-        projectFileConfigurations = request.projectFileConfigurations,
+        wdlParams = request.wdlParams,
         version = request.version
       )
       onComplete(projectConfigurationService.addConfiguration(newProjectConfiguration, accessToken.userId)) {

--- a/controllers/src/test/scala/cromwell/pipeline/controller/ProjectConfigurationControllerTest.scala
+++ b/controllers/src/test/scala/cromwell/pipeline/controller/ProjectConfigurationControllerTest.scala
@@ -26,15 +26,13 @@ class ProjectConfigurationControllerTest extends AsyncWordSpec with Matchers wit
       ProjectConfigurationId.randomId,
       projectId,
       active = true,
-      List(
-        ProjectFileConfiguration(Paths.get("/home/file"), List(FileParameter("nodeName", StringTyped(Some("hello")))))
-      ),
+      WdlParams(Paths.get("/home/file"), List(FileParameter("nodeName", StringTyped(Some("hello"))))),
       ProjectConfigurationVersion.defaultVersion
     )
     val configurationAdditionRequest = ProjectConfigurationAdditionRequest(
       id = configuration.id,
       active = configuration.active,
-      projectFileConfigurations = configuration.projectFileConfigurations,
+      wdlParams = configuration.wdlParams,
       version = configuration.version
     )
     val versionString = "v0.0.2"

--- a/postman/Configurations.postman_collection.json
+++ b/postman/Configurations.postman_collection.json
@@ -6,6 +6,39 @@
 	},
 	"item": [
 		{
+			"name": "Build project configuration by project",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "{{auth_token}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{base_url}}/projects/{{project_id}}/configurations/files/{{project_file_path}}?version=v0.0.1",
+					"host": [
+						"{{base_url}}"
+					],
+					"path": [
+						"projects",
+						"{{project_id}}",
+						"configurations",
+						"files",
+						"{{project_file_path}}"
+					],
+					"query": [
+						{
+							"key": "version",
+							"value": "v0.0.1"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
 			"name": "Add configuration to MongoDB",
 			"request": {
 				"method": "PUT",
@@ -18,7 +51,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"id\": \"\",  \r\n    \"projectFileConfigurations\": [\r\n        {\"path\": \"\", \"inputs\": [\r\n            {\"name\": \"\", \"typedValue\": {\"_type\": \"\", \"value\": \"\"}},\r\n            {\"name\": \"\", \"typedValue\": {\"_type\": \"\", \"value\": \"\"}}\r\n            ]}\r\n    ]\r\n}",
+					"raw": "{\n    \"id\": \"\",\r\n    \"wdlParams\": {\r\n        \"path\": \"\", \r\n        \"inputs\": [\r\n            {\"name\": \"\", \"typedValue\": {\"_type\": \"\", \"value\": \"\"}},\r\n            {\"name\": \"\", \"typedValue\": {\"_type\": \"\", \"value\": \"\"}}\r\n        ]\r\n    }\r\n}",
 					"options": {
 						"raw": {
 							"language": "json"

--- a/postman/Files.postman_collection.json
+++ b/postman/Files.postman_collection.json
@@ -141,39 +141,6 @@
 				}
 			},
 			"response": []
-		},
-		{
-			"name": "Build project configuration by project",
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "Authorization",
-						"value": "{{auth_token}}",
-						"type": "text"
-					}
-				],
-				"url": {
-					"raw": "{{base_url}}/projects/{{project_id}}/files/configurations/{{project_file_path}}?version=v0.0.1",
-					"host": [
-						"{{base_url}}"
-					],
-					"path": [
-						"projects",
-						"{{project_id}}",
-						"files",
-						"configurations",
-						"{{project_file_path}}"
-					],
-					"query": [
-						{
-							"key": "version",
-							"value": "v0.0.1"
-						}
-					]
-				}
-			},
-			"response": []
 		}
 	],
 	"protocolProfileBehavior": {}

--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/CromwellInput.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/CromwellInput.scala
@@ -7,5 +7,5 @@ final case class CromwellInput(
   userId: UserId,
   projectVersion: PipelineVersion,
   files: List[ProjectFile],
-  configurations: List[ProjectFileConfiguration]
+  wdlParams: WdlParams
 )

--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/ProjectConfiguration.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/ProjectConfiguration.scala
@@ -9,10 +9,10 @@ import play.api.libs.json.{ Format, Json, OFormat }
 import java.nio.file.Path
 import java.util.UUID
 
-case class ProjectFileConfiguration(path: Path, inputs: List[FileParameter])
+case class WdlParams(path: Path, inputs: List[FileParameter])
 
-object ProjectFileConfiguration {
-  implicit val projectFileConfigurationFormat: OFormat[ProjectFileConfiguration] = Json.format
+object WdlParams {
+  implicit val wdlParamsFormat: OFormat[WdlParams] = Json.format
 }
 
 final case class ProjectConfigurationVersion(value: VersionValue) extends Ordered[ProjectConfigurationVersion] {
@@ -65,7 +65,7 @@ object ProjectConfigurationId {
 final case class ProjectConfigurationAdditionRequest(
   id: ProjectConfigurationId,
   active: Boolean,
-  projectFileConfigurations: List[ProjectFileConfiguration],
+  wdlParams: WdlParams,
   version: ProjectConfigurationVersion
 )
 
@@ -78,7 +78,7 @@ case class ProjectConfiguration(
   id: ProjectConfigurationId,
   projectId: ProjectId,
   active: Boolean,
-  projectFileConfigurations: List[ProjectFileConfiguration],
+  wdlParams: WdlParams,
   version: ProjectConfigurationVersion
 )
 

--- a/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/ProjectConfigurationRepositoryTest.scala
+++ b/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/ProjectConfigurationRepositoryTest.scala
@@ -16,8 +16,8 @@ class ProjectConfigurationRepositoryTest extends AsyncWordSpec with Matchers wit
 
   private val documentRepository = mock[DocumentRepository]
   private val configurationRepository = ProjectConfigurationRepository(documentRepository)
-  private val projectFileConfiguration: ProjectFileConfiguration =
-    ProjectFileConfiguration(Paths.get("/home/file"), List(FileParameter("nodeName", StringTyped(Some("hello")))))
+  private val wdlParams: WdlParams =
+    WdlParams(Paths.get("/home/file"), List(FileParameter("nodeName", StringTyped(Some("hello")))))
   private val projectId: ProjectId = TestProjectUtils.getDummyProjectId
   private val projectConfigurationId = ProjectConfigurationId.randomId
   private val configuration: ProjectConfiguration =
@@ -25,7 +25,7 @@ class ProjectConfigurationRepositoryTest extends AsyncWordSpec with Matchers wit
       projectConfigurationId,
       projectId,
       active = true,
-      List(projectFileConfiguration),
+      wdlParams,
       ProjectConfigurationVersion.defaultVersion
     )
 

--- a/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/utils/GeneratorUtils.scala
+++ b/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/utils/GeneratorUtils.scala
@@ -124,18 +124,18 @@ object GeneratorUtils {
     typedValue <- typedValueGen
   } yield FileParameter(name, typedValue)
 
-  lazy val projectFileConfigurationGen: Gen[ProjectFileConfiguration] = for {
+  lazy val wdlParamsGen: Gen[WdlParams] = for {
     path <- pathGen
     fileParameters <- listOfN(fileParameterGen)
-  } yield ProjectFileConfiguration(path, fileParameters)
+  } yield WdlParams(path, fileParameters)
 
   lazy val projectConfigurationGen: Gen[ProjectConfiguration] = for {
     id <- projectConfigurationIdGen
     projectId <- projectIdGen
     active <- booleanGen
-    projectFileConfigurations <- listOfN(projectFileConfigurationGen)
+    wdlParams <- wdlParamsGen
     version <- projectConfigurationVersionGen
-  } yield ProjectConfiguration(id, projectId, active, projectFileConfigurations, version)
+  } yield ProjectConfiguration(id, projectId, active, wdlParams, version)
 
   object Mail extends Enumeration {
     val Mail, Gmail, Epam, Yandex = Value

--- a/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/utils/TestProjectUtils.scala
+++ b/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/utils/TestProjectUtils.scala
@@ -26,14 +26,14 @@ object TestProjectUtils {
   def getDummyProjectConfiguration(
     projectId: ProjectId = getDummyProjectId,
     projectConfigurationId: ProjectConfigurationId = ProjectConfigurationId.randomId,
-    projectFileConfiguration: ProjectFileConfiguration =
-      ProjectFileConfiguration(Paths.get("/home/file"), List(FileParameter("nodeName", StringTyped(Some("String")))))
+    wdlParams: WdlParams =
+      WdlParams(Paths.get("/home/file"), List(FileParameter("nodeName", StringTyped(Some("String")))))
   ): ProjectConfiguration = {
     val projectConfiguration: ProjectConfiguration = ProjectConfiguration(
       projectConfigurationId,
       projectId,
       active = true,
-      List(projectFileConfiguration),
+      wdlParams,
       ProjectConfigurationVersion.defaultVersion
     )
     projectConfiguration

--- a/services/src/main/scala/cromwell/pipeline/service/AggregationService.scala
+++ b/services/src/main/scala/cromwell/pipeline/service/AggregationService.scala
@@ -25,16 +25,16 @@ object AggregationService {
         val version = PipelineVersion(run.projectVersion)
         val projectFiles =
           getFilesByProjectId(run.projectId, run.userId, Some(version)).valueOrF(e => Future.failed(e))
-        val futureFileConfigurations =
+        val futureWdlParams =
           projectConfigurationService.getLastByProjectId(run.projectId, run.userId).flatMap {
-            case Some(config) => Future.successful(config.projectFileConfigurations)
+            case Some(config) => Future.successful(config.wdlParams)
             case None =>
               Future.failed(new RuntimeException("Configurations for projectId " + run.projectId + " not found"))
           }
         for {
           files <- projectFiles
-          configs <- futureFileConfigurations
-        } yield CromwellInput(run.projectId, run.userId, version, files, configs)
+          wdlParams <- futureWdlParams
+        } yield CromwellInput(run.projectId, run.userId, version, files, wdlParams)
       }
 
       private def getFilesByProjectId(

--- a/services/src/test/scala/cromwell/pipeline/service/AggregationServiceTest.scala
+++ b/services/src/test/scala/cromwell/pipeline/service/AggregationServiceTest.scala
@@ -32,9 +32,7 @@ class AggregationServiceTest extends AsyncWordSpec with Matchers with MockitoSug
           configurationId,
           projectId,
           active = true,
-          List(
-            ProjectFileConfiguration(path, List(FileParameter("_type", StringTyped(Some("String")))))
-          ),
+          WdlParams(path, List(FileParameter("_type", StringTyped(Some("String"))))),
           ProjectConfigurationVersion.defaultVersion
         )
 
@@ -46,9 +44,7 @@ class AggregationServiceTest extends AsyncWordSpec with Matchers with MockitoSug
           userId,
           version,
           List(file),
-          List(
-            ProjectFileConfiguration(Paths.get("test.wdl"), List(FileParameter("_type", StringTyped(Some("String")))))
-          )
+          WdlParams(Paths.get("test.wdl"), List(FileParameter("_type", StringTyped(Some("String")))))
         )
 
         when(projectService.getUserProjectById(projectId, userId)).thenReturn(Future.successful(dummyProject))

--- a/services/src/test/scala/cromwell/pipeline/service/ProjectConfigurationServiceTestImpl.scala
+++ b/services/src/test/scala/cromwell/pipeline/service/ProjectConfigurationServiceTestImpl.scala
@@ -40,7 +40,7 @@ class ProjectConfigurationServiceTestImpl(projectConfigurations: Seq[ProjectConf
           id = ProjectConfigurationId.randomId,
           projectId = projectId,
           active = true,
-          projectFileConfigurations = List(ProjectFileConfiguration(projectFilePath, Nil)),
+          wdlParams = WdlParams(projectFilePath, Nil),
           version = ProjectConfigurationVersion.defaultVersion
         )
         Future.successful(config)


### PR DESCRIPTION
refactor: Rename ProjectFileConfiguration to WdlParams

ProjectConfiguration constructor now accepts single ProjectFileConfiguration instance.
ProjectFileConfiguration class with all corresponding references was renamed to WdlParams