### PR TITLE
EPMLSTRCMW-266 Codecov doesn't compare to the latest commit in develop

### DIFF
--- a/.github/workflows/cmwl_pipeline_ci.yml
+++ b/.github/workflows/cmwl_pipeline_ci.yml
@@ -1,6 +1,10 @@
 name: CMWL Pipeline CI
 
 on:
+  push:
+    branches:
+      - develop
+      - master
   pull_request:
     branches:
       - develop


### PR DESCRIPTION
chore: Fix codecov upload

In pipeline clone two similar-content branches were created: master and develop. "On push" parameter in `cmwl_pipeline_ci.yml` is on only for "master" branch. 
Similar PRs were formed for each branch. 
After several merges the difference is as follows: https://github.com/Nikolai-Isaev/CodecovTest/pulls