### PR TITLE
EPMLSTRCMW-300 Make filters reusable

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -99,14 +99,14 @@ lazy val repositories =
   (project in file("repositories"))
     .settings(
       Seq(parallelExecution in Test := false),
-      libraryDependencies ++= allTestDependencies ++ jsonDependencies ++ mongoDependencies :+ cats :+ slick :+ slickPg :+ slickPgCore :+ configHokon :+ playJson :+ catsKernel :+ playFunctional
+      libraryDependencies ++= allTestDependencies ++ jsonDependencies ++ mongoDependencies :+ cats :+ slick :+ slickPg :+ slickPgCore :+ slickPgPlayJson :+ configHokon :+ playJson :+ catsKernel :+ playFunctional
     )
     .configs(IntegrationTest)
     .dependsOn(datasource % "compile->compile;test->test", model, utils % "compile->compile;test->test")
 
 lazy val services =
   (project in file("services"))
-    .settings(libraryDependencies ++= jsonDependencies ++ mongoDependencies :+ cats :+ playJson)
+    .settings(libraryDependencies ++= jsonDependencies ++ mongoDependencies :+ cats :+ playJson :+ akkaActor)
     .dependsOn(
       repositories % "compile->compile;test->test",
       utils % "compile->compile;test->test",

--- a/controllers/src/main/scala/cromwell/pipeline/controller/utils/PathMatchers.scala
+++ b/controllers/src/main/scala/cromwell/pipeline/controller/utils/PathMatchers.scala
@@ -11,4 +11,6 @@ object PathMatchers {
   val ProjectId: PathMatcher1[dto.ProjectId] = Segment.map(dto.ProjectId(_))
   val Path: PathMatcher1[Path] = Segment.map(Paths.get(_))
   val RunId: PathMatcher1[wrapper.RunId] = Segment.flatMap(wrapper.RunId.from(_).toOption)
+  val ProjectSearchFilterId: PathMatcher1[wrapper.ProjectSearchFilterId] =
+    Segment.flatMap(wrapper.ProjectSearchFilterId.from(_).toOption)
 }

--- a/controllers/src/test/scala/cromwell/pipeline/controller/ProjectSearchControllerTest.scala
+++ b/controllers/src/test/scala/cromwell/pipeline/controller/ProjectSearchControllerTest.scala
@@ -5,6 +5,8 @@ import akka.http.scaladsl.testkit.ScalatestRouteTest
 import cromwell.pipeline.datastorage.dao.utils.TestProjectUtils
 import cromwell.pipeline.datastorage.dto._
 import cromwell.pipeline.datastorage.dto.auth.AccessTokenContent
+import cromwell.pipeline.model.wrapper.ProjectSearchFilterId
+import cromwell.pipeline.service.ProjectSearchService.Exceptions._
 import cromwell.pipeline.service.impls.ProjectSearchServiceTestImpl
 import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport._
 import org.scalatest.{ AsyncWordSpec, Matchers }
@@ -14,30 +16,29 @@ class ProjectSearchControllerTest extends AsyncWordSpec with Matchers with Scala
   private val dummyProject = TestProjectUtils.getDummyProject()
   private val projects = Seq(dummyProject)
   private val accessToken = AccessTokenContent(dummyProject.ownerId)
-  private val filter = ByConfig(Exists, value = true)
-  private val request = ProjectSearchRequest(filter)
+  private val query = ByConfig(Exists, value = true)
+  private val request = ProjectSearchRequest(query)
+  private val filterId = ProjectSearchFilterId.random
 
   "ProjectSearchController" when {
-    "search projects" should {
+    "search projects by new query" should {
       "Return successful response with seq of projects" in {
-        val searchResponse: ProjectSearchResponse = ProjectSearchResponse(projects)
         val projectSearchService = ProjectSearchServiceTestImpl(dummyProject)
         val projectSearchController = new ProjectSearchController(projectSearchService)
 
         Post("/projects/search", request) ~> projectSearchController.route(accessToken) ~> check {
           status shouldBe StatusCodes.OK
-          responseAs[ProjectSearchResponse] shouldEqual searchResponse
+          responseAs[ProjectSearchResponse].data shouldEqual projects
         }
       }
 
-      "Return successful response with empty seq of projects if no projects was found" in {
-        val searchResponse: ProjectSearchResponse = ProjectSearchResponse(Seq.empty)
+      "Return successful response with empty seq of projects if no projects were found" in {
         val emptyProjectSearchService = ProjectSearchServiceTestImpl()
         val projectSearchController = new ProjectSearchController(emptyProjectSearchService)
 
         Post("/projects/search", request) ~> projectSearchController.route(accessToken) ~> check {
           status shouldBe StatusCodes.OK
-          responseAs[ProjectSearchResponse] shouldEqual searchResponse
+          responseAs[ProjectSearchResponse].data shouldEqual Seq.empty
         }
       }
 
@@ -46,6 +47,46 @@ class ProjectSearchControllerTest extends AsyncWordSpec with Matchers with Scala
         val projectSearchController = new ProjectSearchController(failProjectSearchService)
 
         Post("/projects/search", request) ~> projectSearchController.route(accessToken) ~> check {
+          status shouldBe StatusCodes.InternalServerError
+        }
+      }
+    }
+
+    "search projects by filter Id" should {
+      "Return successful response with seq of projects" in {
+        val projectSearchService = ProjectSearchServiceTestImpl(dummyProject)
+        val projectSearchController = new ProjectSearchController(projectSearchService)
+
+        Get(s"/projects/search/$filterId") ~> projectSearchController.route(accessToken) ~> check {
+          status shouldBe StatusCodes.OK
+          responseAs[ProjectSearchResponse].data shouldEqual projects
+        }
+      }
+
+      "Return successful response with empty seq of projects if no projects were found" in {
+        val emptyProjectSearchService = ProjectSearchServiceTestImpl()
+        val projectSearchController = new ProjectSearchController(emptyProjectSearchService)
+
+        Get(s"/projects/search/$filterId") ~> projectSearchController.route(accessToken) ~> check {
+          status shouldBe StatusCodes.OK
+          responseAs[ProjectSearchResponse].data shouldEqual Seq.empty
+        }
+      }
+
+      "Return 404 if no filter was found by id" in {
+        val emptyProjectSearchService = ProjectSearchServiceTestImpl.withException(NotFound())
+        val projectSearchController = new ProjectSearchController(emptyProjectSearchService)
+
+        Get(s"/projects/search/$filterId") ~> projectSearchController.route(accessToken) ~> check {
+          status shouldBe StatusCodes.NotFound
+        }
+      }
+
+      "Return InternalServerError if search fails" in {
+        val failProjectSearchService = ProjectSearchServiceTestImpl.withException(new RuntimeException)
+        val projectSearchController = new ProjectSearchController(failProjectSearchService)
+
+        Get(s"/projects/search/$filterId") ~> projectSearchController.route(accessToken) ~> check {
           status shouldBe StatusCodes.InternalServerError
         }
       }

--- a/datasource/src/main/resources/liquibase/changelog/changelog-0.1.xml
+++ b/datasource/src/main/resources/liquibase/changelog/changelog-0.1.xml
@@ -111,4 +111,14 @@
         </rollback>
     </changeSet>
 
+    <changeSet id="create_project_search_filter_table" author="nikolai_isaev">
+        <createTable tableName="project_search_filter">
+            <column name="filter_id" type="${uuid.type}"/>
+            <column name="query" type="${json.type}"/>
+            <column name="last_used_at" type="${timestamp.type}"/>
+        </createTable>
+        <addPrimaryKey constraintName="filter_pk" tableName="project_search_filter"
+                       columnNames="filter_id"/>
+    </changeSet>
+
 </databaseChangeLog>

--- a/datasource/src/main/resources/liquibase/changelog/properties.xml
+++ b/datasource/src/main/resources/liquibase/changelog/properties.xml
@@ -12,5 +12,6 @@
     <property name="boolean.type" value="BOOLEAN" dbms="postgresql"/>
     <property name="timestamp.type" value="TIMESTAMP" dbms="postgresql"/>
     <property name="integer.type" value="INTEGER" dbms="postgresql"/>
+    <property name="json.type" value="jsonb" dbms="postgresql"/>
 
 </databaseChangeLog>

--- a/model/src/main/scala/cromwell/pipeline/model/wrapper/ProjectSearchFilterId.scala
+++ b/model/src/main/scala/cromwell/pipeline/model/wrapper/ProjectSearchFilterId.scala
@@ -1,0 +1,23 @@
+package cromwell.pipeline.model.wrapper
+
+import cats.data.{ NonEmptyChain, Validated }
+import cromwell.pipeline.model.validator.Wrapped
+import play.api.libs.json.Format
+
+final class ProjectSearchFilterId private (override val unwrap: String) extends AnyVal with Wrapped[String]
+
+object ProjectSearchFilterId extends Wrapped.Companion {
+  type Type = String
+  type Wrapper = ProjectSearchFilterId
+  type Error = String
+  val pattern: String = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+  implicit lazy val projectSearchIdFormat: Format[ProjectSearchFilterId] = wrapperFormat
+  override protected def create(value: String): ProjectSearchFilterId = new ProjectSearchFilterId(value)
+  override protected def validate(value: String): ValidationResult[String] = Validated.cond(
+    value.matches(pattern),
+    value,
+    NonEmptyChain.one("Invalid ProjectSearchId")
+  )
+
+  def random: ProjectSearchFilterId = new ProjectSearchFilterId(java.util.UUID.randomUUID().toString)
+}

--- a/portal/src/it/resources/application.conf
+++ b/portal/src/it/resources/application.conf
@@ -16,6 +16,13 @@ auth {
   }
 }
 
+service {
+  filtersCleanup {
+      timeToLive = 2 seconds
+      interval = 1 seconds
+  }
+}
+
 database {
   postgres_dc {
     profile = "slick.jdbc.PostgresProfile$"

--- a/portal/src/main/resources/application.conf
+++ b/portal/src/main/resources/application.conf
@@ -20,6 +20,13 @@ auth {
   }
 }
 
+service {
+  filtersCleanup {
+    timeToLive = 7 days
+    interval = 1 day
+  }
+}
+
 database {
   postgres_dc {
     profile = "slick.jdbc.PostgresProfile$"

--- a/postman/ProjectSearch.postman_collection.json
+++ b/postman/ProjectSearch.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "7232e7e3-e677-4348-9cac-129d5f705896",
+		"_postman_id": "ef904f6e-2a2c-4f64-b509-c105b343601b",
 		"name": "ProjectSearch",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -31,7 +31,34 @@
 						"{{base_url}}"
 					],
 					"path": [
-						"projects/search"
+						"projects",
+						"search",
+						""
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Search by filter Id",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "{{auth_token}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{base_url}}/projects/search/{{project_search_id}}",
+					"host": [
+						"{{base_url}}"
+					],
+					"path": [
+						"projects",
+						"search",
+						"{{project_search_id}}"
 					]
 				}
 			},

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -40,6 +40,7 @@ object Dependencies {
   val slick = "com.typesafe.slick" %% "slick" % Version.slick
   val slickPg = "com.github.tminglei" %% "slick-pg" % Version.slickPg
   val slickPgCore = "com.github.tminglei" %% "slick-pg_core" % Version.slickPg
+  val slickPgPlayJson = "com.github.tminglei" %% "slick-pg_play-json" % Version.slickPg
   val hikariCP = "com.typesafe.slick" %% "slick-hikaricp" % Version.hikariCP
   val playJson = "com.typesafe.play" %% "play-json" % Version.playJson
   val playFunctional = "com.typesafe.play" %% "play-functional" % Version.playJson

--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/dao/entry/ProjectEntry.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/dao/entry/ProjectEntry.scala
@@ -6,7 +6,7 @@ import cromwell.pipeline.model.wrapper.UserId
 import slick.lifted.MappedToBase.mappedToIsomorphism
 import slick.lifted.{ ForeignKeyQuery, ProvenShape }
 
-trait ProjectEntry { this: Profile with UserEntry with CustomsWithEnumSupport with AliasesSupport =>
+trait ProjectEntry { this: Profile with UserEntry with MyPostgresProfile with AliasesSupport =>
   import Implicits._
   import api._
 

--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/dao/entry/ProjectSearchFilterEntry.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/dao/entry/ProjectSearchFilterEntry.scala
@@ -1,0 +1,36 @@
+package cromwell.pipeline.datastorage.dao.entry
+
+import cromwell.pipeline.datastorage.Profile
+import cromwell.pipeline.datastorage.dto._
+import cromwell.pipeline.model.wrapper.ProjectSearchFilterId
+import slick.lifted.ProvenShape
+
+import java.time.Instant
+
+trait ProjectSearchFilterEntry { this: Profile with MyPostgresProfile with AliasesSupport =>
+  import Implicits._
+  import api._
+
+  class ProjectSearchFilterTable(tag: Tag) extends Table[ProjectSearchFilter](tag, "project_search_filter") {
+    def filterId: Rep[ProjectSearchFilterId] = column[ProjectSearchFilterId]("filter_id", O.PrimaryKey)
+    def query: Rep[ProjectSearchQuery] = column[ProjectSearchQuery]("query")
+    def lastUsedAt: Rep[Instant] = column[Instant]("last_used_at")
+    override def * : ProvenShape[ProjectSearchFilter] =
+      (filterId, query, lastUsedAt) <> ((ProjectSearchFilter.apply _).tupled, ProjectSearchFilter.unapply)
+  }
+
+  val projectFilters = TableQuery[ProjectSearchFilterTable]
+
+  def getFilterById = Compiled { filterId: Rep[ProjectSearchFilterId] =>
+    projectFilters.filter(_.filterId === filterId).take(1)
+  }
+
+  def addFilter(projectSearchFilter: ProjectSearchFilter): ActionResult[ProjectSearchFilterId] =
+    projectFilters.returning(projectFilters.map(_.filterId)) += projectSearchFilter
+
+  def updateLastUsedAt(filterId: ProjectSearchFilterId, lastUsedAt: Instant): ActionResult[Int] =
+    projectFilters.filter(_.filterId === filterId).map(searchFilter => searchFilter.lastUsedAt).update(lastUsedAt)
+
+  def deleteOldFilters(usedLaterThan: Instant): ActionResult[Int] =
+    projectFilters.filter(_.lastUsedAt <= usedLaterThan).delete
+}

--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/dao/entry/RunEntry.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/dao/entry/RunEntry.scala
@@ -7,7 +7,7 @@ import cromwell.pipeline.datastorage.dto._
 import cromwell.pipeline.model.wrapper.{ RunId, UserId }
 import slick.lifted.{ ForeignKeyQuery, ProvenShape }
 
-trait RunEntry { this: Profile with UserEntry with ProjectEntry with CustomsWithEnumSupport with AliasesSupport =>
+trait RunEntry { this: Profile with UserEntry with ProjectEntry with MyPostgresProfile with AliasesSupport =>
   import Implicits._
   import api._
 

--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/dao/repository/ProjectSearchFilterRepository.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/dao/repository/ProjectSearchFilterRepository.scala
@@ -1,0 +1,48 @@
+package cromwell.pipeline.datastorage.dao.repository
+
+import cromwell.pipeline.database.PipelineDatabaseEngine
+import cromwell.pipeline.datastorage.dao.entry.ProjectSearchFilterEntry
+import cromwell.pipeline.datastorage.dto.ProjectSearchFilter
+import cromwell.pipeline.model.wrapper.ProjectSearchFilterId
+
+import java.time.Instant
+import scala.concurrent.Future
+
+trait ProjectSearchFilterRepository {
+
+  def addProjectSearchFilter(projectSearchFilter: ProjectSearchFilter): Future[ProjectSearchFilterId]
+
+  def getProjectSearchFilterById(projectSearchFilterId: ProjectSearchFilterId): Future[Option[ProjectSearchFilter]]
+
+  def updateLastUsedAt(projectSearchId: ProjectSearchFilterId, lastUsedAt: Instant): Future[Int]
+
+  def deleteOldFilters(usedLaterThan: Instant): Future[Int]
+}
+
+object ProjectSearchFilterRepository {
+
+  def apply(
+    pipelineDatabaseEngine: PipelineDatabaseEngine,
+    projectSearchFilterEntry: ProjectSearchFilterEntry
+  ): ProjectSearchFilterRepository =
+    new ProjectSearchFilterRepository {
+
+      import pipelineDatabaseEngine._
+      import pipelineDatabaseEngine.profile.api._
+
+      override def addProjectSearchFilter(projectSearchFilter: ProjectSearchFilter): Future[ProjectSearchFilterId] =
+        database.run(projectSearchFilterEntry.addFilter(projectSearchFilter))
+
+      override def getProjectSearchFilterById(
+        projectSearchFilterId: ProjectSearchFilterId
+      ): Future[Option[ProjectSearchFilter]] =
+        database.run(projectSearchFilterEntry.getFilterById(projectSearchFilterId).result.headOption)
+
+      override def updateLastUsedAt(projectSearchId: ProjectSearchFilterId, lastUsedAt: Instant): Future[Int] =
+        database.run(projectSearchFilterEntry.updateLastUsedAt(projectSearchId, lastUsedAt))
+
+      override def deleteOldFilters(usedLaterThan: Instant): Future[Int] =
+        database.run(projectSearchFilterEntry.deleteOldFilters(usedLaterThan))
+    }
+
+}

--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/MyPostgresProfile.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/MyPostgresProfile.scala
@@ -1,14 +1,17 @@
 package cromwell.pipeline.datastorage.dto
 
-import com.github.tminglei.slickpg.PgEnumSupport
+import com.github.tminglei.slickpg.{ ExPostgresProfile, PgEnumSupport, PgPlayJsonSupport }
 import slick.basic.Capability
-import slick.jdbc.{ JdbcType, PostgresProfile }
+import slick.jdbc.JdbcType
 
-trait CustomsWithEnumSupport extends PostgresProfile with PgEnumSupport {
+trait MyPostgresProfile extends ExPostgresProfile with PgEnumSupport with PgPlayJsonSupport {
+
+  def pgjson = "jsonb"
+
   override protected def computeCapabilities: Set[Capability] =
     super.computeCapabilities + slick.jdbc.JdbcCapabilities.insertOrUpdate
-  override val api: API = new API {}
-  trait API extends super.API {
+  override val api = MyAPI
+  object MyAPI extends API with JsonImplicits {
     implicit val visibilityTypeMapper: JdbcType[Visibility] =
       createEnumJdbcType[Visibility]("visibility_type", Visibility.toString, Visibility.fromString, quoteName = false)
     implicit val visibilityTypeListMapper: JdbcType[List[Visibility]] =

--- a/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/ProjectSearchFilterRepositoryTest.scala
+++ b/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/ProjectSearchFilterRepositoryTest.scala
@@ -1,0 +1,94 @@
+package cromwell.pipeline.datastorage.dao.repository
+
+import com.dimafeng.testcontainers.{ ForAllTestContainer, PostgreSQLContainer }
+import com.typesafe.config.Config
+import cromwell.pipeline.datastorage.DatastorageModule
+import cromwell.pipeline.datastorage.dao.utils.PostgreTablesCleaner
+import cromwell.pipeline.datastorage.dto.{ ByName, FullMatch, ProjectSearchFilter }
+import cromwell.pipeline.model.wrapper.ProjectSearchFilterId
+import cromwell.pipeline.utils.{ ApplicationConfig, TestContainersUtils }
+import org.scalatest.{ AsyncWordSpec, BeforeAndAfterAll, Matchers }
+
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+class ProjectSearchFilterRepositoryTest
+    extends AsyncWordSpec
+    with Matchers
+    with BeforeAndAfterAll
+    with ForAllTestContainer
+    with PostgreTablesCleaner {
+
+  override val container: PostgreSQLContainer = TestContainersUtils.getPostgreSQLContainer()
+  protected lazy val config: Config = TestContainersUtils.getConfigForPgContainer(container)
+  protected lazy val datastorageModule: DatastorageModule = new DatastorageModule(ApplicationConfig.load(config))
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll
+    datastorageModule.pipelineDatabaseEngine.updateSchema()
+  }
+
+  import datastorageModule.projectSearchFilterRepository
+
+  "ProjectSearchFilterRepository" when {
+
+    "getProjectSearchFilterById" should {
+
+      "find added projectSearchFilter by id" taggedAs Dao in {
+        val query = ByName(mode = FullMatch, value = "Hello")
+        val projectSearchFilter = ProjectSearchFilter(ProjectSearchFilterId.random, query, Instant.now)
+
+        val result = for {
+          filterId <- projectSearchFilterRepository.addProjectSearchFilter(projectSearchFilter)
+          filter <- projectSearchFilterRepository.getProjectSearchFilterById(filterId)
+        } yield filter
+
+        result.map(_ shouldBe Some(projectSearchFilter))
+      }
+    }
+
+    "getProjectSearchFilterById" should {
+
+      "not find expired projectSearchFilter" in {
+        val query = ByName(mode = FullMatch, value = "Hello")
+        val currentTime = Instant.now
+        val allowedTtlInSec = 15
+        val expiredTtlInSec = 30
+
+        val lastAllowedUseTime = currentTime.minus(allowedTtlInSec, ChronoUnit.MINUTES)
+        val expiredLastUsedTime = currentTime.minus(expiredTtlInSec, ChronoUnit.MINUTES)
+        val expiredProjectSearchFilter = ProjectSearchFilter(ProjectSearchFilterId.random, query, expiredLastUsedTime)
+
+        val result = for {
+          expiredFilterId <- projectSearchFilterRepository.addProjectSearchFilter(expiredProjectSearchFilter)
+          _ <- projectSearchFilterRepository.deleteOldFilters(lastAllowedUseTime)
+          search <- projectSearchFilterRepository.getProjectSearchFilterById(expiredFilterId)
+        } yield search
+
+        result.map(_ shouldBe None)
+      }
+    }
+
+    "update lastUsedAt" should {
+
+      "update lastUsedAt of project search filter" in {
+        val query = ByName(mode = FullMatch, value = "Hello")
+        val expiredTtlInSec = 30
+        val passedTime = Instant.now.minus(expiredTtlInSec, ChronoUnit.SECONDS)
+        val currentTime = Instant.now
+        val searchId = ProjectSearchFilterId.random
+        val projectSearch = ProjectSearchFilter(searchId, query, passedTime)
+        val expectedResult = Some(ProjectSearchFilter(searchId, query, currentTime))
+
+        val result = for {
+          searchId <- projectSearchFilterRepository.addProjectSearchFilter(projectSearch)
+          _ <- projectSearchFilterRepository.updateLastUsedAt(searchId, currentTime)
+          search <- projectSearchFilterRepository.getProjectSearchFilterById(searchId)
+        } yield search
+
+        result.map(_ shouldBe expectedResult)
+      }
+    }
+  }
+
+}

--- a/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/impls/ProjectSearchFilterRepositoryTestImpl.scala
+++ b/repositories/src/test/scala/cromwell/pipeline/datastorage/dao/repository/impls/ProjectSearchFilterRepositoryTestImpl.scala
@@ -1,0 +1,56 @@
+package cromwell.pipeline.datastorage.dao.repository.impls
+
+import cromwell.pipeline.datastorage.dao.repository.ProjectSearchFilterRepository
+import cromwell.pipeline.datastorage.dto.ProjectSearchFilter
+import cromwell.pipeline.model.wrapper.ProjectSearchFilterId
+
+import java.time.Instant
+import scala.collection.mutable
+import scala.concurrent.Future
+
+class ProjectSearchFilterRepositoryTestImpl extends ProjectSearchFilterRepository {
+
+  private val searches: mutable.Map[ProjectSearchFilterId, ProjectSearchFilter] = mutable.Map.empty
+
+  def getProjectSearchFilterById(projectSearchFilterId: ProjectSearchFilterId): Future[Option[ProjectSearchFilter]] =
+    Future.successful(searches.get(projectSearchFilterId))
+
+  def addProjectSearchFilter(search: ProjectSearchFilter): Future[ProjectSearchFilterId] = {
+    searches += (search.id -> search)
+    Future.successful(search.id)
+  }
+
+  def updateLastUsedAt(projectSearchId: ProjectSearchFilterId, timestart: Instant): Future[Int] =
+    Future.successful(1)
+
+  def deleteOldFilters(usedLaterThan: Instant): Future[Int] =
+    Future.successful(1)
+}
+
+object ProjectSearchFilterRepositoryTestImpl {
+
+  def apply(searches: ProjectSearchFilter*): ProjectSearchFilterRepositoryTestImpl = {
+    val projectSearchRepositoryTestImpl = new ProjectSearchFilterRepositoryTestImpl
+    searches.foreach(projectSearchRepositoryTestImpl.addProjectSearchFilter)
+    projectSearchRepositoryTestImpl
+  }
+
+  def withException(exception: Throwable): ProjectSearchFilterRepository =
+    new ProjectSearchFilterRepository {
+
+      override def addProjectSearchFilter(projectSearch: ProjectSearchFilter): Future[ProjectSearchFilterId] =
+        Future.failed(exception)
+
+      override def getProjectSearchFilterById(
+        projectSearchFilterId: ProjectSearchFilterId
+      ): Future[Option[ProjectSearchFilter]] =
+        Future.failed(exception)
+
+      override def updateLastUsedAt(projectSearchId: ProjectSearchFilterId, timestart: Instant): Future[Int] =
+        Future.failed(exception)
+
+      override def deleteOldFilters(usedLaterThan: Instant): Future[Int] =
+        Future.failed(exception)
+    }
+
+}

--- a/services/src/main/scala/cromwell/pipeline/service/ProjectSearchEngine.scala
+++ b/services/src/main/scala/cromwell/pipeline/service/ProjectSearchEngine.scala
@@ -1,0 +1,137 @@
+package cromwell.pipeline.service
+
+import cromwell.pipeline.datastorage.dto._
+import cromwell.pipeline.model.wrapper.UserId
+import cromwell.pipeline.service.ProjectSearchEngine.Exceptions._
+import cromwell.pipeline.service.exceptions.ServiceException
+
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.{ Failure, Success }
+
+trait ProjectSearchEngine {
+
+  def searchProjects(query: ProjectSearchQuery, userId: UserId): Future[Seq[Project]]
+
+}
+
+object ProjectSearchEngine {
+
+  object Exceptions {
+    sealed abstract class ProjectSearchEngineException(message: String) extends ServiceException(message)
+    final case class InternalError(message: String = "Internal error") extends ProjectSearchEngineException(message)
+  }
+  // scalastyle:off method.length
+  def apply(
+    projectService: ProjectService,
+    projectFileService: ProjectFileService,
+    projectConfigurationService: ProjectConfigurationService
+  )(implicit ec: ExecutionContext): ProjectSearchEngine =
+    new ProjectSearchEngine {
+
+      override def searchProjects(query: ProjectSearchQuery, userId: UserId): Future[Seq[Project]] = {
+
+        def doSearch(searchQuery: ProjectSearchQuery, projects: Seq[Project]): Future[Seq[Project]] =
+          searchQuery match {
+            case All                   => Future.successful(projects)
+            case ByName(mode, value)   => Future.successful(searchByName(mode, value, projects))
+            case ByFiles(mode, value)  => searchByFiles(mode, value, projects, userId)
+            case ByConfig(mode, value) => searchByConfig(mode, value, projects, userId)
+
+            case Or(leftQuery, rightQuery) =>
+              for {
+                leftRes <- doSearch(leftQuery, projects)
+                rightRes <- doSearch(rightQuery, projects)
+              } yield (leftRes ++ rightRes).distinct
+
+            case And(leftQuery, rightQuery) =>
+              for {
+                leftRes <- doSearch(leftQuery, projects)
+                result <- doSearch(rightQuery, leftRes)
+              } yield result
+          }
+
+        for {
+          userProjects <- projectService.getUserProjects(userId).recoverWith {
+            case _ => internalError("fetch projects")
+          }
+          filteredProjects <- doSearch(query, userProjects)
+        } yield filteredProjects
+
+      }
+
+      private def searchByConfig(
+        mode: ContentSearchMode,
+        value: Boolean,
+        projects: Seq[Project],
+        userId: UserId
+      ): Future[Seq[Project]] =
+        mode match {
+          case Exists => searchByConfigExists(value, projects, userId)
+        }
+
+      private def searchByConfigExists(
+        hasConfig: Boolean,
+        projects: Seq[Project],
+        userId: UserId
+      ): Future[Seq[Project]] = {
+        def getProjectWithConfig(project: Project): Future[(Project, Option[ProjectConfiguration])] =
+          projectConfigurationService.getLastByProjectId(project.projectId, userId).transformWith {
+            case Success(configuration) => Future.successful(project, Some(configuration))
+            case Failure(ProjectConfigurationService.Exceptions.NotFound(_)) =>
+              Future.successful(project, None)
+            case Failure(_) => internalError("fetch configuration")
+          }
+
+        for {
+          projWithConf <- Future.sequence(projects.map(getProjectWithConfig))
+        } yield projWithConf.collect {
+          case (proj, Some(_)) if hasConfig => proj
+          case (proj, None) if !hasConfig   => proj
+        }
+      }
+
+      private def searchByFiles(
+        mode: ContentSearchMode,
+        value: Boolean,
+        projects: Seq[Project],
+        userId: UserId
+      ): Future[Seq[Project]] =
+        mode match {
+          case Exists => searchByFilesExist(value, projects, userId)
+        }
+
+      private def searchByFilesExist(
+        hasFiles: Boolean,
+        projects: Seq[Project],
+        userId: UserId
+      ): Future[Seq[Project]] = {
+        def getProjectWithFiles(project: Project): Future[(Project, List[ProjectFile])] =
+          projectFileService
+            .getFiles(project.projectId, None, userId)
+            .recoverWith {
+              case _ => internalError("fetch files")
+            }
+            .map(files => (project, files))
+
+        for {
+          projWithFiles <- Future.sequence(projects.map(getProjectWithFiles))
+        } yield projWithFiles.collect {
+          case (proj, list) if list.nonEmpty == hasFiles => proj
+        }
+      }
+
+      private def searchByName(
+        mode: NameSearchMode,
+        value: String,
+        userProjects: Seq[Project]
+      ): Seq[Project] =
+        mode match {
+          case FullMatch   => userProjects.filter(_.name == value)
+          case RegexpMatch => userProjects.filter(_.name.matches(value))
+        }
+
+      private def internalError(action: String): Future[Nothing] =
+        Future.failed(InternalError(s"Failed to $action due to unexpected internal error"))
+    }
+  // scalastyle:on method.length
+}

--- a/services/src/main/scala/cromwell/pipeline/service/ProjectSearchFilterCleaner.scala
+++ b/services/src/main/scala/cromwell/pipeline/service/ProjectSearchFilterCleaner.scala
@@ -1,0 +1,36 @@
+package cromwell.pipeline.service
+
+import akka.actor.ActorSystem
+import cromwell.pipeline.utils.FiltersCleanupConfig
+
+import java.time.Instant
+import scala.concurrent.ExecutionContext
+
+trait ProjectSearchFilterCleaner {
+
+  def scheduleFiltersCleanup(): Unit
+
+}
+
+object ProjectSearchFilterCleaner {
+
+  def apply(
+    projectSearchFilterService: ProjectSearchFilterService,
+    filtersCleanupConfig: FiltersCleanupConfig,
+    system: ActorSystem
+  )(
+    implicit executionContext: ExecutionContext
+  ): ProjectSearchFilterCleaner =
+    new ProjectSearchFilterCleaner {
+
+      import filtersCleanupConfig._
+
+      override def scheduleFiltersCleanup(): Unit =
+        system.scheduler.scheduleAtFixedRate(interval, interval, getFiltersCleanRun, executionContext)
+
+      private def getFiltersCleanRun: Runnable = () => {
+        val usedLaterThan = Instant.now.minus(timeToLive)
+        projectSearchFilterService.deleteOldFilters(usedLaterThan)
+      }
+    }
+}

--- a/services/src/main/scala/cromwell/pipeline/service/ProjectSearchFilterService.scala
+++ b/services/src/main/scala/cromwell/pipeline/service/ProjectSearchFilterService.scala
@@ -1,0 +1,75 @@
+package cromwell.pipeline.service
+
+import cromwell.pipeline.datastorage.dao.repository.ProjectSearchFilterRepository
+import cromwell.pipeline.datastorage.dto.{ ProjectSearchFilter, ProjectSearchQuery }
+import cromwell.pipeline.model.wrapper.ProjectSearchFilterId
+import cromwell.pipeline.service.ProjectSearchFilterService.Exceptions._
+import cromwell.pipeline.service.exceptions.ServiceException
+
+import java.time.Instant
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.Success
+
+trait ProjectSearchFilterService {
+
+  def addProjectSearchFilter(filter: ProjectSearchQuery): Future[ProjectSearchFilterId]
+
+  def getSearchFilterById(searchId: ProjectSearchFilterId): Future[ProjectSearchFilter]
+
+  def updateLastUsedAt(searchId: ProjectSearchFilterId, lastUsedAt: Instant): Future[Unit]
+
+  def deleteOldFilters(usedLaterThan: Instant): Future[Unit]
+
+}
+
+object ProjectSearchFilterService {
+
+  object Exceptions {
+    sealed abstract class ProjectSearchFilterServiceException(message: String) extends ServiceException(message)
+    final case class NotFound(message: String = "Filter with that Id does not exist")
+        extends ProjectSearchFilterServiceException(message)
+    final case class InternalError(message: String = "Internal error")
+        extends ProjectSearchFilterServiceException(message)
+  }
+
+  def apply(projectSearchFilterRepository: ProjectSearchFilterRepository)(
+    implicit executionContext: ExecutionContext
+  ): ProjectSearchFilterService =
+    new ProjectSearchFilterService {
+
+      override def addProjectSearchFilter(query: ProjectSearchQuery): Future[ProjectSearchFilterId] = {
+        val projectSearchFilter = ProjectSearchFilter(
+          id = ProjectSearchFilterId.random,
+          query = query,
+          lastUsedAt = Instant.now
+        )
+        projectSearchFilterRepository.addProjectSearchFilter(projectSearchFilter).recoverWith {
+          case _ => internalError("add filter")
+        }
+      }
+
+      override def getSearchFilterById(filterId: ProjectSearchFilterId): Future[ProjectSearchFilter] =
+        projectSearchFilterRepository.getProjectSearchFilterById(filterId).transformWith {
+          case Success(Some(projectFilter)) => Future.successful(projectFilter)
+          case Success(None)                => Future.failed(NotFound())
+          case _                            => internalError("find filter")
+        }
+
+      override def updateLastUsedAt(searchId: ProjectSearchFilterId, lastUsedAt: Instant): Future[Unit] =
+        projectSearchFilterRepository.updateLastUsedAt(searchId, lastUsedAt).transformWith {
+          case Success(_) => Future.unit
+          case _          => internalError("update lastUsedAt")
+        }
+
+      override def deleteOldFilters(usedLaterThan: Instant): Future[Unit] =
+        projectSearchFilterRepository.deleteOldFilters(usedLaterThan).transformWith {
+          case Success(_) => Future.unit
+          case _          => internalError("delete old filters")
+        }
+
+      private def internalError(action: String): Future[Nothing] =
+        Future.failed(InternalError(s"Failed to $action due to unexpected internal error"))
+
+    }
+
+}

--- a/services/src/main/scala/cromwell/pipeline/service/ProjectSearchService.scala
+++ b/services/src/main/scala/cromwell/pipeline/service/ProjectSearchService.scala
@@ -1,17 +1,18 @@
 package cromwell.pipeline.service
 
 import cromwell.pipeline.datastorage.dto._
-import cromwell.pipeline.model.wrapper.UserId
-import cromwell.pipeline.service.ProjectConfigurationService.Exceptions.NotFound
+import cromwell.pipeline.model.wrapper.{ ProjectSearchFilterId, UserId }
 import cromwell.pipeline.service.ProjectSearchService.Exceptions._
 import cromwell.pipeline.service.exceptions.ServiceException
 
+import java.time.Instant
 import scala.concurrent.{ ExecutionContext, Future }
-import scala.util.{ Failure, Success }
 
 trait ProjectSearchService {
 
-  def searchProjects(request: ProjectSearchRequest, userId: UserId): Future[ProjectSearchResponse]
+  def searchProjectsByFilterId(filterId: ProjectSearchFilterId, userId: UserId): Future[ProjectSearchResponse]
+
+  def searchProjectsByNewQuery(request: ProjectSearchRequest, userId: UserId): Future[ProjectSearchResponse]
 
 }
 
@@ -19,124 +20,64 @@ object ProjectSearchService {
 
   object Exceptions {
     sealed abstract class ProjectSearchException(message: String) extends ServiceException(message)
+    final case class NotFound(message: String = "Filter not found") extends ProjectSearchException(message)
     final case class InternalError(message: String = "Internal error") extends ProjectSearchException(message)
   }
 
-  // scalastyle:off method.length
   def apply(
     projectService: ProjectService,
-    projectFileService: ProjectFileService,
-    projectConfigurationService: ProjectConfigurationService
+    projectSearchFilterService: ProjectSearchFilterService,
+    searchEngine: ProjectSearchEngine
   )(
     implicit ec: ExecutionContext
   ): ProjectSearchService =
     new ProjectSearchService {
 
-      override def searchProjects(request: ProjectSearchRequest, userId: UserId): Future[ProjectSearchResponse] = {
-
-        def doSearch(searchFilter: ProjectSearchFilter, projects: Seq[Project]): Future[Seq[Project]] =
-          searchFilter match {
-            case All                   => Future.successful(projects)
-            case ByName(mode, value)   => Future.successful(searchByNameFilter(mode, value, projects))
-            case ByFiles(mode, value)  => searchByFiles(mode, value, projects, userId)
-            case ByConfig(mode, value) => searchByConfig(mode, value, projects, userId)
-
-            case Or(leftFilter, rightFilter) =>
-              for {
-                leftRes <- doSearch(leftFilter, projects)
-                rightRes <- doSearch(rightFilter, projects)
-              } yield (leftRes ++ rightRes).distinct
-
-            case And(leftFilter, rightFilter) =>
-              for {
-                leftRes <- doSearch(leftFilter, projects)
-                result <- doSearch(rightFilter, leftRes)
-              } yield result
-          }
-
-        for {
-          userProjects <- projectService.getUserProjects(userId).recoverWith {
-            case _ => internalError("fetch projects")
-          }
-          filteredProjects <- doSearch(request.filter, userProjects)
-        } yield ProjectSearchResponse(filteredProjects)
-
-      }
-
-      private def searchByConfig(
-        mode: ContentSearchMode,
-        value: Boolean,
-        projects: Seq[Project],
+      override def searchProjectsByFilterId(
+        filterId: ProjectSearchFilterId,
         userId: UserId
-      ): Future[Seq[Project]] =
-        mode match {
-          case Exists => searchByConfigExists(value, projects, userId)
+      ): Future[ProjectSearchResponse] =
+        for {
+          projectSearchFilter <- getSearchFilterById(filterId)
+          _ <- updateProjectSearchFilterLastUsedAt(filterId)
+          projects <- searchProjects(projectSearchFilter.query, userId)
+        } yield ProjectSearchResponse(filterId, projects)
+
+      override def searchProjectsByNewQuery(
+        request: ProjectSearchRequest,
+        userId: UserId
+      ): Future[ProjectSearchResponse] =
+        for {
+          searchId <- addProjectSearchFilter(request.filter)
+          projects <- searchProjects(request.filter, userId)
+        } yield ProjectSearchResponse(searchId, projects)
+
+      private def searchProjects(query: ProjectSearchQuery, userId: UserId): Future[Seq[Project]] =
+        searchEngine.searchProjects(query, userId).recoverWith {
+          case _ => internalError("process search query")
         }
 
-      private def searchByConfigExists(
-        hasConfig: Boolean,
-        projects: Seq[Project],
-        userId: UserId
-      ): Future[Seq[Project]] = {
-        def getProjectWithConfig(project: Project): Future[(Project, Option[ProjectConfiguration])] =
-          projectConfigurationService.getLastByProjectId(project.projectId, userId).transformWith {
-            case Success(configuration) => Future.successful(project, Some(configuration))
-            case Failure(NotFound(_))   => Future.successful(project, None)
-            case _                      => internalError("fetch configuration")
-          }
-
-        for {
-          projWithConf <- Future.sequence(projects.map(getProjectWithConfig))
-        } yield projWithConf.collect {
-          case (proj, Some(_)) if hasConfig => proj
-          case (proj, None) if !hasConfig   => proj
+      private def updateProjectSearchFilterLastUsedAt(filterId: ProjectSearchFilterId): Future[Unit] = {
+        val currentTime = Instant.now
+        projectSearchFilterService.updateLastUsedAt(filterId, currentTime).recoverWith {
+          case _ => internalError("update lastUsedAt")
         }
       }
 
-      private def searchByFiles(
-        mode: ContentSearchMode,
-        value: Boolean,
-        projects: Seq[Project],
-        userId: UserId
-      ): Future[Seq[Project]] =
-        mode match {
-          case Exists => searchByFilesExist(value, projects, userId)
+      private def addProjectSearchFilter(query: ProjectSearchQuery): Future[ProjectSearchFilterId] =
+        projectSearchFilterService.addProjectSearchFilter(query).recoverWith {
+          case _ => internalError("save filter")
         }
 
-      private def searchByFilesExist(
-        hasFiles: Boolean,
-        projects: Seq[Project],
-        userId: UserId
-      ): Future[Seq[Project]] = {
-        def getProjectWithFiles(project: Project): Future[(Project, List[ProjectFile])] =
-          projectFileService
-            .getFiles(project.projectId, None, userId)
-            .recoverWith {
-              case _ => internalError("fetch files")
-            }
-            .map(files => (project, files))
-
-        for {
-          projWithFiles <- Future.sequence(projects.map(getProjectWithFiles))
-        } yield projWithFiles.collect {
-          case (proj, list) if list.nonEmpty == hasFiles => proj
-        }
-      }
-
-      private def searchByNameFilter(
-        mode: NameSearchMode,
-        value: String,
-        userProjects: Seq[Project]
-      ): Seq[Project] =
-        mode match {
-          case FullMatch   => userProjects.filter(_.name == value)
-          case RegexpMatch => userProjects.filter(_.name.matches(value))
+      private def getSearchFilterById(searchId: ProjectSearchFilterId): Future[ProjectSearchFilter] =
+        projectSearchFilterService.getSearchFilterById(searchId).recoverWith {
+          case ProjectSearchFilterService.Exceptions.NotFound(_) => Future.failed(NotFound())
+          case _                                                 => internalError("fetch filter")
         }
 
       private def internalError(action: String): Future[Nothing] =
         Future.failed(InternalError(s"Failed to $action due to unexpected internal error"))
 
     }
-  // scalastyle:on method.length
 
 }

--- a/services/src/main/scala/cromwell/pipeline/service/ServiceModule.scala
+++ b/services/src/main/scala/cromwell/pipeline/service/ServiceModule.scala
@@ -26,9 +26,15 @@ class ServiceModule(
       womToolModule.womTool,
       projectVersioning
     )
-  lazy val projectSearchService: ProjectSearchService =
-    ProjectSearchService(projectService, projectFileService, configurationService)
   lazy val projectFileService: ProjectFileService =
     ProjectFileService(projectService, configurationService, womToolModule.womTool, projectVersioning)
   lazy val runService: RunService = RunService(datastorageModule.runRepository, projectService)
+  lazy val projectSearchFilterService: ProjectSearchFilterService = ProjectSearchFilterService(
+    datastorageModule.projectSearchFilterRepository
+  )
+  lazy val projectSearchEngine: ProjectSearchEngine =
+    ProjectSearchEngine(projectService, projectFileService, configurationService)
+  lazy val projectSearchService: ProjectSearchService =
+    ProjectSearchService(projectService, projectSearchFilterService, projectSearchEngine)
+
 }

--- a/services/src/test/scala/cromwell/pipeline/service/ProjectSearchEngineTest.scala
+++ b/services/src/test/scala/cromwell/pipeline/service/ProjectSearchEngineTest.scala
@@ -1,0 +1,197 @@
+package cromwell.pipeline.service
+
+import cromwell.pipeline.datastorage.dao.utils.TestProjectUtils
+import cromwell.pipeline.datastorage.dto._
+import cromwell.pipeline.model.wrapper.UserId
+import cromwell.pipeline.service.ProjectSearchEngine.Exceptions.InternalError
+import cromwell.pipeline.service.impls.{
+  ProjectConfigurationServiceTestImpl,
+  ProjectFileServiceTestImpl,
+  ProjectServiceTestImpl
+}
+import org.scalatest.{ AsyncWordSpec, Matchers }
+
+import java.nio.file.Paths
+
+class ProjectSearchEngineTest extends AsyncWordSpec with Matchers {
+
+  private val dummyProject1: Project = TestProjectUtils.getDummyProject(name = "First")
+  private val projectId: ProjectId = dummyProject1.projectId
+  private val userId: UserId = dummyProject1.ownerId
+  private val dummyProject2 = TestProjectUtils.getDummyProject(ownerId = userId, name = "Second")
+  private val dummyProject3 = TestProjectUtils.getDummyProject(ownerId = userId, name = "Third")
+  private val dummyProjects = Seq(dummyProject1, dummyProject2, dummyProject3)
+
+  private val correctWdl = "task hello {}"
+  private val projectFilePath = Paths.get("test.txt")
+  private val projectFileContent = ProjectFileContent(correctWdl)
+  private val projectFile = ProjectFile(projectFilePath, projectFileContent)
+  private val dummyProject1FileBundle = (dummyProject1.projectId, Seq(projectFile))
+  private val dummyProject2FileBundle = (dummyProject2.projectId, Seq(projectFile))
+  private val dummyProject3FileBundle = (dummyProject3.projectId, Seq.empty)
+
+  private val wdlParams: WdlParams =
+    WdlParams(Paths.get("/home/file"), List(FileParameter("nodeName", StringTyped(Some("hello")))))
+  private val projectConfigurationId = ProjectConfigurationId.randomId
+
+  private val activeConfiguration1: ProjectConfiguration =
+    ProjectConfiguration(
+      projectConfigurationId,
+      projectId,
+      active = true,
+      wdlParams,
+      ProjectConfigurationVersion.defaultVersion
+    )
+  private val activeConfiguration2: ProjectConfiguration =
+    activeConfiguration1.copy(projectId = dummyProject2.projectId)
+
+  private val defaultProjectService = ProjectServiceTestImpl(dummyProjects: _*)
+  private val defaultProjectFileService =
+    ProjectFileServiceTestImpl(dummyProject1FileBundle, dummyProject2FileBundle, dummyProject3FileBundle)
+  private val defaultProjectConfigurationService =
+    ProjectConfigurationServiceTestImpl(activeConfiguration1, activeConfiguration2)
+
+  private def createProjectSearchEngine(
+    projectService: ProjectService = defaultProjectService,
+    projectFileService: ProjectFileService = defaultProjectFileService,
+    projectConfigurationService: ProjectConfigurationService = defaultProjectConfigurationService
+  ): ProjectSearchEngine =
+    ProjectSearchEngine(projectService, projectFileService, projectConfigurationService)
+
+  private val projectSearchEngine = createProjectSearchEngine()
+
+  "ProjectSearchServiceTest" when {
+    "search successfully for all projects" should {
+      "return list of all projects" in {
+        val query = All
+        val result = dummyProjects
+
+        projectSearchEngine.searchProjects(query, userId).map(_ shouldBe result)
+      }
+    }
+
+    "search project by name full match" should {
+      "return full matched project" in {
+        val name = dummyProject1.name
+        val query = ByName(FullMatch, name)
+        val result = Seq(dummyProject1)
+
+        projectSearchEngine.searchProjects(query, userId).map(_ shouldBe result)
+      }
+      "return empty result if nothing matched" in {
+        val projectName = "UNMATCHED"
+        val query = ByName(RegexpMatch, projectName)
+        val result = Seq.empty
+
+        projectSearchEngine.searchProjects(query, userId).map(_ shouldBe result)
+      }
+    }
+
+    "search project by name regexp match" should {
+      "return matched projects" in {
+        val regexString = ".*ir.*"
+        val query = ByName(RegexpMatch, regexString)
+        val result = Seq(dummyProject1, dummyProject3)
+
+        projectSearchEngine.searchProjects(query, userId).map(_ shouldBe result)
+      }
+      "return empty result if nothing matched" in {
+        val regexString = ".*UNMATCHED.*"
+        val query = ByName(RegexpMatch, regexString)
+        val result = Seq.empty
+
+        projectSearchEngine.searchProjects(query, userId).map(_ shouldBe result)
+      }
+    }
+
+    "search project by config" should {
+      "return projects with configuration if Exists true" in {
+        val query = ByConfig(mode = Exists, value = true)
+        val result = Seq(dummyProject1, dummyProject2)
+
+        projectSearchEngine.searchProjects(query, userId).map(_ shouldBe result)
+      }
+      "return project without configuration if Exists false" in {
+        val query = ByConfig(mode = Exists, value = false)
+        val result = Seq(dummyProject3)
+
+        projectSearchEngine.searchProjects(query, userId).map(_ shouldBe result)
+      }
+      "fail with exception if unable to fetch configuration" in {
+        val failedConfigService = ProjectConfigurationServiceTestImpl.withException(new RuntimeException)
+        val projectSearch = createProjectSearchEngine(projectConfigurationService = failedConfigService)
+
+        val query = ByConfig(mode = Exists, value = true)
+
+        projectSearch.searchProjects(query, userId).failed.map {
+          _ shouldBe InternalError("Failed to fetch configuration due to unexpected internal error")
+        }
+      }
+    }
+
+    "search project by files" should {
+      "return projects with files if Exists true" in {
+        val query = ByFiles(mode = Exists, value = true)
+
+        val result = Seq(dummyProject1, dummyProject2)
+
+        projectSearchEngine.searchProjects(query, userId).map(_ shouldBe result)
+      }
+      "return project without files if Exists false" in {
+        val query = ByFiles(mode = Exists, value = false)
+        val result = Seq(dummyProject3)
+
+        projectSearchEngine.searchProjects(query, userId).map(_ shouldBe result)
+      }
+      "fail with exception if unable to fetch configuration" in {
+        val failedFilesService = ProjectFileServiceTestImpl.withException(new RuntimeException)
+        val projectSearch = createProjectSearchEngine(projectFileService = failedFilesService)
+
+        val query = ByFiles(mode = Exists, value = true)
+
+        projectSearch.searchProjects(query, userId).failed.map {
+          _ shouldBe InternalError("Failed to fetch files due to unexpected internal error")
+        }
+      }
+    }
+    "search project by And query" should {
+      "return only projects suitable for both conditions" in {
+        val byFiles = ByFiles(mode = Exists, value = true)
+        val byName = ByName(mode = RegexpMatch, value = ".*ir.*")
+        val andQuery = And(byFiles, byName)
+
+        val result = Seq(dummyProject1)
+
+        projectSearchEngine.searchProjects(andQuery, userId).map(_ shouldBe result)
+      }
+    }
+
+    "search project with complex query" should {
+      "return filtered projects" in {
+        val byNameFullMatch = ByName(FullMatch, dummyProject3.name)
+        val byConfigExist = ByConfig(mode = Exists, value = true)
+        val byFilesExist = ByFiles(mode = Exists, value = true)
+        val byFilesNotExist = ByFiles(mode = Exists, value = false)
+        val byBothFilesAndConfigsExist = And(byFilesExist, byConfigExist)
+        val byFullNameMatchAndFilesNotExist = And(byNameFullMatch, byFilesNotExist)
+        val complexOrQuery = Or(byBothFilesAndConfigsExist, byFullNameMatchAndFilesNotExist)
+
+        val result = Seq(dummyProject1, dummyProject2, dummyProject3)
+
+        projectSearchEngine.searchProjects(complexOrQuery, userId).map(_ shouldBe result)
+      }
+    }
+
+    "do any search" should {
+      "fail with exception if unable to fetch user projects" in {
+        val failedProjectService = ProjectServiceTestImpl.withException(new RuntimeException)
+        val projectSearch = createProjectSearchEngine(projectService = failedProjectService)
+        val query = All
+
+        projectSearch.searchProjects(query, userId).failed.map {
+          _ shouldBe InternalError("Failed to fetch projects due to unexpected internal error")
+        }
+      }
+    }
+  }
+}

--- a/services/src/test/scala/cromwell/pipeline/service/ProjectSearchFilterServiceTest.scala
+++ b/services/src/test/scala/cromwell/pipeline/service/ProjectSearchFilterServiceTest.scala
@@ -1,0 +1,79 @@
+package cromwell.pipeline.service
+
+import cromwell.pipeline.datastorage.dao.repository.impls.ProjectSearchFilterRepositoryTestImpl
+import cromwell.pipeline.datastorage.dto.{ All, ProjectSearchFilter }
+import cromwell.pipeline.model.wrapper.ProjectSearchFilterId
+import cromwell.pipeline.service.ProjectSearchFilterService.Exceptions._
+import org.scalatest.{ AsyncWordSpec, Matchers }
+
+import java.time.Instant
+class ProjectSearchFilterServiceTest extends AsyncWordSpec with Matchers {
+
+  private val query = All
+  private val currentTime = Instant.now
+  private val projectSearchFilter = ProjectSearchFilter(ProjectSearchFilterId.random, query, currentTime)
+
+  "ProjectSearchFilterServiceTest" when {
+    "add search filter" should {
+      "run successfully" in {
+        val projectSearchRepository = ProjectSearchFilterRepositoryTestImpl(projectSearchFilter)
+        val projectSearchFilterService = ProjectSearchFilterService(projectSearchRepository)
+
+        projectSearchFilterService.addProjectSearchFilter(query).map(_ => succeed)
+      }
+      "fail with internal error if projectSearchFilterRepository fails" in {
+
+        val failedPprojectSearchRepository = ProjectSearchFilterRepositoryTestImpl.withException(new RuntimeException)
+        val projectSearchFilterService = ProjectSearchFilterService(failedPprojectSearchRepository)
+
+        projectSearchFilterService.addProjectSearchFilter(query).failed.map {
+          _ shouldBe InternalError("Failed to add filter due to unexpected internal error")
+        }
+      }
+    }
+
+    "get search filter by id" should {
+      "return query" in {
+        val projectSearchRepository = ProjectSearchFilterRepositoryTestImpl(projectSearchFilter)
+        val projectSearchFilterService = ProjectSearchFilterService(projectSearchRepository)
+
+        projectSearchFilterService.getSearchFilterById(projectSearchFilter.id).map(_ shouldBe projectSearchFilter)
+      }
+      "fail with internal error if projectSearchRepository fails" in {
+
+        val failedProjectSearchRepository = ProjectSearchFilterRepositoryTestImpl.withException(new RuntimeException)
+        val projectSearchFilterService = ProjectSearchFilterService(failedProjectSearchRepository)
+
+        projectSearchFilterService.getSearchFilterById(projectSearchFilter.id).failed.map {
+          _ shouldBe InternalError("Failed to find filter due to unexpected internal error")
+        }
+      }
+      "fail with NotFound if projectSearchFilter is not found" in {
+
+        val failedProjectSearchRepository = ProjectSearchFilterRepositoryTestImpl()
+        val projectSearchFilterService = ProjectSearchFilterService(failedProjectSearchRepository)
+
+        projectSearchFilterService.getSearchFilterById(projectSearchFilter.id).failed.map {
+          _ shouldBe NotFound()
+        }
+      }
+    }
+
+    "update lastUsedAt" should {
+      "return unit if succeeded" in {
+        val projectSearchRepository = ProjectSearchFilterRepositoryTestImpl(projectSearchFilter)
+        val projectSearchFilterService = ProjectSearchFilterService(projectSearchRepository)
+
+        projectSearchFilterService.updateLastUsedAt(projectSearchFilter.id, currentTime).map(_ shouldBe ((): Unit))
+      }
+      "fail with internal error if projectSearchFilterService fails" in {
+        val failedProjectSearchRepository = ProjectSearchFilterRepositoryTestImpl.withException(new RuntimeException)
+        val projectSearchFilterService = ProjectSearchFilterService(failedProjectSearchRepository)
+
+        projectSearchFilterService.updateLastUsedAt(projectSearchFilter.id, currentTime).failed.map {
+          _ shouldBe InternalError("Failed to update lastUsedAt due to unexpected internal error")
+        }
+      }
+    }
+  }
+}

--- a/services/src/test/scala/cromwell/pipeline/service/ProjectSearchServiceTest.scala
+++ b/services/src/test/scala/cromwell/pipeline/service/ProjectSearchServiceTest.scala
@@ -2,205 +2,100 @@ package cromwell.pipeline.service
 
 import cromwell.pipeline.datastorage.dao.utils.TestProjectUtils
 import cromwell.pipeline.datastorage.dto._
-import cromwell.pipeline.model.wrapper.UserId
-import cromwell.pipeline.service.ProjectSearchService.Exceptions.InternalError
+import cromwell.pipeline.model.wrapper.{ ProjectSearchFilterId, UserId }
+import cromwell.pipeline.service.ProjectSearchService.Exceptions._
 import cromwell.pipeline.service.impls.{
-  ProjectConfigurationServiceTestImpl,
-  ProjectFileServiceTestImpl,
+  ProjectSearchEngineTestImpl,
+  ProjectSearchFilterServiceTestImpl,
   ProjectServiceTestImpl
 }
 import org.scalatest.{ AsyncWordSpec, Matchers }
 
-import java.nio.file.Paths
+import java.time.Instant
 
 class ProjectSearchServiceTest extends AsyncWordSpec with Matchers {
 
   private val dummyProject1: Project = TestProjectUtils.getDummyProject(name = "First")
-  private val projectId: ProjectId = dummyProject1.projectId
   private val userId: UserId = dummyProject1.ownerId
   private val dummyProject2 = TestProjectUtils.getDummyProject(ownerId = userId, name = "Second")
   private val dummyProject3 = TestProjectUtils.getDummyProject(ownerId = userId, name = "Third")
   private val dummyProjects = Seq(dummyProject1, dummyProject2, dummyProject3)
-
-  private val correctWdl = "task hello {}"
-  private val projectFilePath = Paths.get("test.txt")
-  private val projectFileContent = ProjectFileContent(correctWdl)
-  private val projectFile = ProjectFile(projectFilePath, projectFileContent)
-  private val dummyProject1FileBundle = (dummyProject1.projectId, Seq(projectFile))
-  private val dummyProject2FileBundle = (dummyProject2.projectId, Seq(projectFile))
-  private val dummyProject3FileBundle = (dummyProject3.projectId, Seq.empty)
-
-  private val wdlParams: WdlParams =
-    WdlParams(Paths.get("/home/file"), List(FileParameter("nodeName", StringTyped(Some("hello")))))
-  private val projectConfigurationId = ProjectConfigurationId.randomId
-
-  private val activeConfiguration1: ProjectConfiguration =
-    ProjectConfiguration(
-      projectConfigurationId,
-      projectId,
-      active = true,
-      wdlParams,
-      ProjectConfigurationVersion.defaultVersion
-    )
-  private val activeConfiguration2: ProjectConfiguration =
-    activeConfiguration1.copy(projectId = dummyProject2.projectId)
+  private val filterId = ProjectSearchFilterId.random
+  private val currentTime = Instant.now
+  private val filter = ProjectSearchFilter(filterId, All, currentTime)
+  private val request = ProjectSearchRequest(All)
 
   private val defaultProjectService = ProjectServiceTestImpl(dummyProjects: _*)
-  private val defaultProjectFileService =
-    ProjectFileServiceTestImpl(dummyProject1FileBundle, dummyProject2FileBundle, dummyProject3FileBundle)
-  private val defaultProjectConfigurationService =
-    ProjectConfigurationServiceTestImpl(activeConfiguration1, activeConfiguration2)
+  private val defaultFilterService = ProjectSearchFilterServiceTestImpl(filter)
+  private val defaultProjectSearchEngine = ProjectSearchEngineTestImpl(dummyProjects: _*)
 
   private def createProjectSearchService(
     projectService: ProjectService = defaultProjectService,
-    projectFileService: ProjectFileService = defaultProjectFileService,
-    projectConfigurationService: ProjectConfigurationService = defaultProjectConfigurationService
+    filterService: ProjectSearchFilterService = defaultFilterService,
+    searchEngine: ProjectSearchEngine = defaultProjectSearchEngine
   ): ProjectSearchService =
-    ProjectSearchService(projectService, projectFileService, projectConfigurationService)
+    ProjectSearchService(projectService, filterService, searchEngine)
 
-  private val projectSearch = createProjectSearchService()
+  private val projectSearchService = createProjectSearchService()
 
   "ProjectSearchServiceTest" when {
-    "search successfully for all projects" should {
-      "return list of all projects" in {
-        val request = ProjectSearchRequest(All)
-        val result = ProjectSearchResponse(dummyProjects)
+    "searchProjectsByNewFilter" should {
+      "return response with new id and seq of projects" in {
+        val resultProjects = dummyProjects
 
-        projectSearch.searchProjects(request, userId).map(_ shouldBe result)
+        projectSearchService.searchProjectsByNewQuery(request, userId).map(_.data shouldBe resultProjects)
       }
-    }
+      "fail with exception if unable to add new filter" in {
+        val projectSearchService = createProjectSearchService(
+          filterService = ProjectSearchFilterServiceTestImpl.withException(new RuntimeException)
+        )
 
-    "search project by name full match" should {
-      "return full matched project" in {
-        val name = dummyProject1.name
-        val filter = ByName(FullMatch, name)
-        val request = ProjectSearchRequest(filter)
-        val result = ProjectSearchResponse(Seq(dummyProject1))
-
-        projectSearch.searchProjects(request, userId).map(_ shouldBe result)
+        projectSearchService.searchProjectsByNewQuery(request, userId).failed.map {
+          _ shouldBe InternalError("Failed to save filter due to unexpected internal error")
+        }
       }
-      "return empty result if nothing matched" in {
-        val projectName = "UNMATCHED"
-        val filter = ByName(RegexpMatch, projectName)
-        val request = ProjectSearchRequest(filter)
-        val result = ProjectSearchResponse(Seq.empty)
+      "fail with exception if searchEngine fails" in {
+        val projectSearchService = createProjectSearchService(
+          searchEngine = ProjectSearchEngineTestImpl.withException(new RuntimeException)
+        )
 
-        projectSearch.searchProjects(request, userId).map(_ shouldBe result)
-      }
-    }
-
-    "search project by name regexp match" should {
-      "return matched projects" in {
-        val regexString = ".*ir.*"
-        val filter = ByName(RegexpMatch, regexString)
-        val request = ProjectSearchRequest(filter)
-        val result = ProjectSearchResponse(Seq(dummyProject1, dummyProject3))
-
-        projectSearch.searchProjects(request, userId).map(_ shouldBe result)
-      }
-      "return empty result if nothing matched" in {
-        val regexString = ".*UNMATCHED.*"
-        val filter = ByName(RegexpMatch, regexString)
-        val request = ProjectSearchRequest(filter)
-        val result = ProjectSearchResponse(Seq.empty)
-
-        projectSearch.searchProjects(request, userId).map(_ shouldBe result)
-      }
-    }
-
-    "search project by config" should {
-      "return projects with configuration if Exists true" in {
-        val filter = ByConfig(mode = Exists, value = true)
-        val request = ProjectSearchRequest(filter)
-        val result = ProjectSearchResponse(Seq(dummyProject1, dummyProject2))
-
-        projectSearch.searchProjects(request, userId).map(_ shouldBe result)
-      }
-      "return project without configuration if Exists false" in {
-        val filter = ByConfig(mode = Exists, value = false)
-        val request = ProjectSearchRequest(filter)
-        val result = ProjectSearchResponse(Seq(dummyProject3))
-
-        projectSearch.searchProjects(request, userId).map(_ shouldBe result)
-      }
-      "fail with exception if unable to fetch configuration" in {
-        val failedConfigService = ProjectConfigurationServiceTestImpl.withException(new RuntimeException)
-        val projectSearch = createProjectSearchService(projectConfigurationService = failedConfigService)
-
-        val filter = ByConfig(mode = Exists, value = true)
-        val request = ProjectSearchRequest(filter)
-
-        projectSearch.searchProjects(request, userId).failed.map {
-          _ shouldBe InternalError("Failed to fetch configuration due to unexpected internal error")
+        projectSearchService.searchProjectsByNewQuery(request, userId).failed.map {
+          _ shouldBe InternalError("Failed to process search query due to unexpected internal error")
         }
       }
     }
 
-    "search project by files" should {
-      "return projects with files if Exists true" in {
-        val filter = ByFiles(mode = Exists, value = true)
-        val request = ProjectSearchRequest(filter)
-        val result = ProjectSearchResponse(Seq(dummyProject1, dummyProject2))
+    "searchProjectsByFilterId" should {
+      "return response with id and seq of projects" in {
+        val result = ProjectSearchResponse(filterId, dummyProjects)
 
-        projectSearch.searchProjects(request, userId).map(_ shouldBe result)
+        projectSearchService.searchProjectsByFilterId(filterId, userId).map(_ shouldBe result)
       }
-      "return project without files if Exists false" in {
-        val filter = ByFiles(mode = Exists, value = false)
-        val request = ProjectSearchRequest(filter)
-        val result = ProjectSearchResponse(Seq(dummyProject3))
+      "fail with exception if filter is not found" in {
+        val projectSearchService = createProjectSearchService(
+          filterService = ProjectSearchFilterServiceTestImpl()
+        )
 
-        projectSearch.searchProjects(request, userId).map(_ shouldBe result)
-      }
-      "fail with exception if unable to fetch configuration" in {
-        val failedFilesService = ProjectFileServiceTestImpl.withException(new RuntimeException)
-        val projectSearch = createProjectSearchService(projectFileService = failedFilesService)
-
-        val filter = ByFiles(mode = Exists, value = true)
-        val request = ProjectSearchRequest(filter)
-
-        projectSearch.searchProjects(request, userId).failed.map {
-          _ shouldBe InternalError("Failed to fetch files due to unexpected internal error")
+        projectSearchService.searchProjectsByFilterId(filterId, userId).failed.map {
+          _ shouldBe NotFound()
         }
       }
-    }
-    "search project by And filter" should {
-      "return only projects suitable for both conditions" in {
-        val filterByFiles = ByFiles(mode = Exists, value = true)
-        val filterByName = ByName(mode = RegexpMatch, value = ".*ir.*")
-        val filterAnd = And(filterByFiles, filterByName)
+      "fail with exception if searchEngine fails" in {
+        val projectSearchService = createProjectSearchService(
+          searchEngine = ProjectSearchEngineTestImpl.withException(new RuntimeException)
+        )
 
-        val request = ProjectSearchRequest(filterAnd)
-        val result = ProjectSearchResponse(Seq(dummyProject1))
-
-        projectSearch.searchProjects(request, userId).map(_ shouldBe result)
+        projectSearchService.searchProjectsByNewQuery(request, userId).failed.map {
+          _ shouldBe InternalError("Failed to process search query due to unexpected internal error")
+        }
       }
-    }
+      "fail with exception if filter timestart update fails" in {
+        val projectSearchService = createProjectSearchService(
+          searchEngine = ProjectSearchEngineTestImpl.withException(new RuntimeException)
+        )
 
-    "search project with complex filter" should {
-      "return filtered projects" in {
-        val filterByNameFullMatch = ByName(FullMatch, dummyProject3.name)
-        val filterConfigExist = ByConfig(mode = Exists, value = true)
-        val filterFilesExist = ByFiles(mode = Exists, value = true)
-        val filterFilesNotExist = ByFiles(mode = Exists, value = false)
-        val filterBothFilesAndConfigsExist = And(filterFilesExist, filterConfigExist)
-        val filterFullNameMatchAndFilesNotExist = And(filterByNameFullMatch, filterFilesNotExist)
-        val complexFilter = Or(filterBothFilesAndConfigsExist, filterFullNameMatchAndFilesNotExist)
-
-        val request = ProjectSearchRequest(complexFilter)
-        val result = ProjectSearchResponse(Seq(dummyProject1, dummyProject2, dummyProject3))
-
-        projectSearch.searchProjects(request, userId).map(_ shouldBe result)
-      }
-    }
-
-    "do any search" should {
-      "fail with exception if unable to fetch user projects" in {
-        val failedProjectService = ProjectServiceTestImpl.withException(new RuntimeException)
-        val projectSearch = createProjectSearchService(projectService = failedProjectService)
-        val request = ProjectSearchRequest(All)
-
-        projectSearch.searchProjects(request, userId).failed.map {
-          _ shouldBe InternalError("Failed to fetch projects due to unexpected internal error")
+        projectSearchService.searchProjectsByNewQuery(request, userId).failed.map {
+          _ shouldBe InternalError("Failed to process search query due to unexpected internal error")
         }
       }
     }

--- a/services/src/test/scala/cromwell/pipeline/service/impls/ProjectSearchEngineTestImpl.scala
+++ b/services/src/test/scala/cromwell/pipeline/service/impls/ProjectSearchEngineTestImpl.scala
@@ -1,0 +1,26 @@
+package cromwell.pipeline.service.impls
+
+import cromwell.pipeline.datastorage.dto.{ Project, ProjectSearchQuery }
+import cromwell.pipeline.model.wrapper.UserId
+import cromwell.pipeline.service.ProjectSearchEngine
+
+import scala.concurrent.Future
+
+class ProjectSearchEngineTestImpl(projects: Seq[Project], testMode: TestMode) extends ProjectSearchEngine {
+
+  override def searchProjects(query: ProjectSearchQuery, userId: UserId): Future[Seq[Project]] =
+    testMode match {
+      case WithException(exc) => Future.failed(exc)
+      case _                  => Future.successful(projects)
+    }
+}
+
+object ProjectSearchEngineTestImpl {
+
+  def apply(projects: Project*): ProjectSearchEngineTestImpl =
+    new ProjectSearchEngineTestImpl(projects = projects, testMode = Success)
+
+  def withException(exception: Throwable): ProjectSearchEngineTestImpl =
+    new ProjectSearchEngineTestImpl(projects = Seq.empty, testMode = WithException(exception))
+
+}

--- a/services/src/test/scala/cromwell/pipeline/service/impls/ProjectSearchFilterServiceTestImpl.scala
+++ b/services/src/test/scala/cromwell/pipeline/service/impls/ProjectSearchFilterServiceTestImpl.scala
@@ -1,0 +1,51 @@
+package cromwell.pipeline.service.impls
+
+import cromwell.pipeline.datastorage.dto.{ ProjectSearchFilter, ProjectSearchQuery }
+import cromwell.pipeline.model.wrapper.ProjectSearchFilterId
+import cromwell.pipeline.service.ProjectSearchFilterService
+
+import java.time.Instant
+import scala.concurrent.Future
+
+class ProjectSearchFilterServiceTestImpl(projectSearchFilters: Seq[ProjectSearchFilter], testMode: TestMode)
+    extends ProjectSearchFilterService {
+
+  def addProjectSearchFilter(query: ProjectSearchQuery): Future[ProjectSearchFilterId] =
+    testMode match {
+      case WithException(exc) => Future.failed(exc)
+      case _                  => Future.successful(ProjectSearchFilterId.random)
+    }
+
+  def getSearchFilterById(filterId: ProjectSearchFilterId): Future[ProjectSearchFilter] =
+    testMode match {
+      case WithException(exc) => Future.failed(exc)
+      case _ =>
+        projectSearchFilters.headOption match {
+          case Some(filter) => Future.successful(filter)
+          case None         => Future.failed(ProjectSearchFilterService.Exceptions.NotFound())
+        }
+    }
+
+  def updateLastUsedAt(filterId: ProjectSearchFilterId, lastUsedAt: Instant): Future[Unit] =
+    testMode match {
+      case WithException(exc) => Future.failed(exc)
+      case _                  => Future.unit
+    }
+
+  def deleteOldFilters(usedLaterThan: Instant): Future[Unit] =
+    testMode match {
+      case WithException(exc) => Future.failed(exc)
+      case _                  => Future.unit
+    }
+
+}
+
+object ProjectSearchFilterServiceTestImpl {
+
+  def apply(filters: ProjectSearchFilter*): ProjectSearchFilterServiceTestImpl =
+    new ProjectSearchFilterServiceTestImpl(projectSearchFilters = filters, testMode = Success)
+
+  def withException(exception: Throwable): ProjectSearchFilterServiceTestImpl =
+    new ProjectSearchFilterServiceTestImpl(projectSearchFilters = Seq.empty, testMode = WithException(exception))
+
+}

--- a/services/src/test/scala/cromwell/pipeline/service/impls/ProjectSearchServiceTestImpl.scala
+++ b/services/src/test/scala/cromwell/pipeline/service/impls/ProjectSearchServiceTestImpl.scala
@@ -1,19 +1,27 @@
 package cromwell.pipeline.service.impls
 
 import cromwell.pipeline.datastorage.dto.{ Project, ProjectSearchRequest, ProjectSearchResponse }
-import cromwell.pipeline.model.wrapper.UserId
+import cromwell.pipeline.model.wrapper.{ ProjectSearchFilterId, UserId }
 import cromwell.pipeline.service.ProjectSearchService
 
 import scala.concurrent.Future
 
 class ProjectSearchServiceTestImpl(projects: Seq[Project], testMode: TestMode) extends ProjectSearchService {
 
-  override def searchProjects(request: ProjectSearchRequest, userId: UserId): Future[ProjectSearchResponse] =
+  override def searchProjectsByFilterId(
+    filterId: ProjectSearchFilterId,
+    userId: UserId
+  ): Future[ProjectSearchResponse] =
     testMode match {
       case WithException(exc) => Future.failed(exc)
-      case _                  => Future.successful(ProjectSearchResponse(projects))
+      case _                  => Future.successful(ProjectSearchResponse(filterId, projects))
     }
 
+  override def searchProjectsByNewQuery(request: ProjectSearchRequest, userId: UserId): Future[ProjectSearchResponse] =
+    testMode match {
+      case WithException(exc) => Future.failed(exc)
+      case _                  => Future.successful(ProjectSearchResponse(ProjectSearchFilterId.random, projects))
+    }
 }
 
 object ProjectSearchServiceTestImpl {

--- a/utils/src/test/scala/cromwell/pipeline/utils/configs/ConfigJsonOpsTest.scala
+++ b/utils/src/test/scala/cromwell/pipeline/utils/configs/ConfigJsonOpsTest.scala
@@ -24,6 +24,12 @@ class ConfigJsonOpsTest extends WordSpec {
        |    userSession = 30
        |  }
        |}
+       |service {
+       |  filtersCleanup {
+       |    timeToLive = 7 days
+       |    interval = 1 day
+       |  }
+       |}
        |database {
        |  postgres_dc {
        |    profile = "dbProfile"
@@ -70,6 +76,12 @@ class ConfigJsonOpsTest extends WordSpec {
        |    accessToken = 10
        |    refreshToken = 20
        |    userSession = 30
+       |  }
+       |}
+       |service {
+       |  filtersCleanup {
+       |    timeToLive = 7 days
+       |    interval = 1 day
        |  }
        |}
        |database {
@@ -148,6 +160,12 @@ class ConfigJsonOpsTest extends WordSpec {
        |    "databaseName" : "postgre",
        |    "user" : "postgreUser",
        |    "password" : "*********"
+       |  },
+       |  "ServiceConfig" : {
+       |    "filtersCleanup" : {
+       |      "timeToLive" : "PT168H",
+       |      "interval" : "PT24H"
+       |    }
        |  }
        |}""".stripMargin
 
@@ -196,6 +214,12 @@ class ConfigJsonOpsTest extends WordSpec {
        |    "databaseName" : "postgre",
        |    "user" : "postgreUser",
        |    "password" : ""
+       |  },
+       |  "ServiceConfig" : {
+       |    "filtersCleanup" : {
+       |      "timeToLive" : "PT168H",
+       |      "interval" : "PT24H"
+       |    }
        |  }
        |}""".stripMargin
 


### PR DESCRIPTION
feat: Make search filters reusable

- Added project_search pg table
- Added ProjectSearchRepository, corresponding ProjectSearchFilterService
- New service class ProjectSearchEngine containing search filter processing logic
was separated from ProjectSearchService
- ProjectSearchController now supports fetching search results both by new filter
and by search id