### PR TITLE
EPMLSTRCMW-288 Fix or rewrite getFileVersions method in GitLabProjectVersioning

### DIFF
--- a/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/Project.scala
+++ b/repositories/src/main/scala/cromwell/pipeline/datastorage/dto/Project.scala
@@ -128,6 +128,11 @@ object PipelineVersion {
   implicit val pipelineVersionFormat: Format[PipelineVersion] =
     implicitly[Format[String]].inmap(PipelineVersion.apply, _.name)
 }
+final case class GLFileCommitInfo(id: Commit, message: PipelineVersion)
+object GLFileCommitInfo {
+  implicit val versionFromCommitFormat: OFormat[GLFileCommitInfo] =
+    Json.format[GLFileCommitInfo]
+}
 
 final case class Commit(id: String)
 object Commit {


### PR DESCRIPTION
fix: Make getFileVersions & getFileCommits work

- Both PipelineVersion and commit id are now received via
repository/commits gitlab route