### PR TITLE
EPMLSTRCMW-245 Test reports are not generated for some classes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ lazy val commonSettings = Seq(
   },
   compile in Compile := (compile in Compile).dependsOn(checkFormat, checkScalastyle).value,
   test in Test := (test in Test).dependsOn(checkFormat, checkScalastyle).value,
-  testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-h", "target/test-reports"),
+  testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-o", "-h", "target/test-reports"),
   coverageEnabled in Test := true,
   coverageMinimum := 50,
   coverageFailOnMinimum := true,


### PR DESCRIPTION
Reconfigured build.sbt with proper flags passed into testOptions:
-o means standard output, -h saves reports as xml files inside specific directory, that's been passed as the last argument